### PR TITLE
Feature/supporting objects

### DIFF
--- a/src/apex/buildConfig.json
+++ b/src/apex/buildConfig.json
@@ -58,26 +58,25 @@
       [
         { "content_type": "plaintext", "path": "plsql/", "name": "flow_types_pkg.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_constants_pkg.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_api_pkg.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_boundary_events.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_migrate_xml_pkg.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_bpmn_parser_pkg.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_api_pkg.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_engine_util.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_engine.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_errors.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_expressions.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_gateways.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_globals.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_instances.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_logging.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_plsql_runner_pkg.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_process_vars.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_reservations.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_boundary_events.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_tasks.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_services.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_timers_pkg.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_instances.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_engine.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_reservations.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_process_vars.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_expressions.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_usertask_pkg.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/engine-app/", "name": "flow_p0005_api.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/engine-app/", "name": "flow_p0006_api.pks", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/engine-app/", "name": "flow_p0007_api.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_plsql_runner_pkg.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_logging.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_globals.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_errors.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/engine-app/", "name": "flow_engine_app_api.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plugins/manage-flow-instance/plsql/", "name": "flow_plugin_manage_instance.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plugins/manage-flow-instance-step/plsql/", "name": "flow_plugin_manage_instance_step.pks", "add_show_errors": false }
@@ -101,20 +100,20 @@
     , "keepTempFiles": false
     , "content":
       [
-        { "content_type": "plaintext", "path": "/", "name": "flow_diagram_categories_lov.sql", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "/", "name": "flow_diagrams_parsed_lov.sql", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "/", "name": "flow_diagrams_vw.sql", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "/", "name": "flow_instances_vw.sql", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "/", "name": "flow_instance_connections_lov.sql", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "/", "name": "flow_instance_details_vw.sql", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "/", "name": "flow_instance_gateways_lov.sql", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "/", "name": "flow_instance_variables_vw.sql", "add_show_errors": false }
+        { "content_type": "plaintext", "path": "/", "name": "flow_instances_vw.sql", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "/", "name": "flow_subflows_vw.sql", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "/", "name": "flow_diagrams_parsed_lov.sql", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "/", "name": "flow_diagram_categories_lov.sql", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "/", "name": "flow_instance_details_vw.sql", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "/", "name": "flow_instance_variables_vw.sql", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "/", "name": "flow_task_inbox_vw.sql", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "/", "name": "flow_instance_connections_lov.sql", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "/", "name": "flow_instance_gateways_lov.sql", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "/", "name": "flow_diagrams_vw.sql", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "engine-app/", "name": "flow_p0002_diagrams_vw.sql", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "engine-app/", "name": "flow_p0007_instances_counter_vw.sql", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "engine-app/", "name": "flow_p0008_instance_log_vw.sql", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "engine-app/", "name": "flow_p0008_instance_details_vw.sql", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "engine-app/", "name": "flow_p0008_instance_log_vw.sql", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "engine-app/", "name": "flow_p0008_subflows_vw.sql", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "engine-app/", "name": "flow_p0008_variables_vw.sql", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "engine-app/", "name": "flow_p0008_vw.sql", "add_show_errors": false }
@@ -147,26 +146,25 @@
     , "keepTempFiles": false
     , "content":
       [
-        { "content_type": "plaintext", "path": "plsql/", "name": "flow_api_pkg.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_boundary_events.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_bpmn_parser_pkg.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_engine_util.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_engine.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_errors.pkb", "add_show_errors": false }
+        { "content_type": "plaintext", "path": "plsql/", "name": "flow_process_vars.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_expressions.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_gateways.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_globals.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_instances.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_logging.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_plsql_runner_pkg.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_process_vars.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_reservations.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_engine_util.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_gateways.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_boundary_events.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_tasks.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_services.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_instances.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_engine.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_api_pkg.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_migrate_xml_pkg.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_bpmn_parser_pkg.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_timers_pkg.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_usertask_pkg.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/engine-app/", "name": "flow_p0005_api.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/engine-app/", "name": "flow_p0006_api.pkb", "add_show_errors": false }
-      , { "content_type": "plaintext", "path": "plsql/engine-app/", "name": "flow_p0007_api.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_plsql_runner_pkg.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_logging.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_globals.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_errors.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/engine-app/", "name": "flow_engine_app_api.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plugins/manage-flow-instance/plsql/", "name": "flow_plugin_manage_instance.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plugins/manage-flow-instance-step/plsql/", "name": "flow_plugin_manage_instance_step.pkb", "add_show_errors": false }

--- a/src/apex/buildConfig.json
+++ b/src/apex/buildConfig.json
@@ -77,7 +77,9 @@
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_logging.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_globals.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_errors.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_diagram.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/engine-app/", "name": "flow_engine_app_api.pks", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/engine-app/", "name": "flow_theme_api.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plugins/manage-flow-instance/plsql/", "name": "flow_plugin_manage_instance.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plugins/manage-flow-instance-step/plsql/", "name": "flow_plugin_manage_instance_step.pks", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plugins/manage-flow-instance-variables/plsql/", "name": "flow_plugin_manage_instance_variables.pks", "add_show_errors": false }
@@ -110,6 +112,9 @@
       , { "content_type": "plaintext", "path": "/", "name": "flow_instance_connections_lov.sql", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "/", "name": "flow_instance_gateways_lov.sql", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "/", "name": "flow_diagrams_vw.sql", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "/", "name": "flow_objects_vw.sql", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "/", "name": "flow_processes_vw.sql", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "/", "name": "flow_process_variables_vw.sql", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "engine-app/", "name": "flow_p0002_diagrams_vw.sql", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "engine-app/", "name": "flow_p0007_instances_counter_vw.sql", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "engine-app/", "name": "flow_p0008_instance_details_vw.sql", "add_show_errors": false }
@@ -165,7 +170,9 @@
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_logging.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_globals.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/", "name": "flow_errors.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/", "name": "flow_diagram.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plsql/engine-app/", "name": "flow_engine_app_api.pkb", "add_show_errors": false }
+      , { "content_type": "plaintext", "path": "plsql/engine-app/", "name": "flow_theme_api.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plugins/manage-flow-instance/plsql/", "name": "flow_plugin_manage_instance.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plugins/manage-flow-instance-step/plsql/", "name": "flow_plugin_manage_instance_step.pkb", "add_show_errors": false }
       , { "content_type": "plaintext", "path": "plugins/manage-flow-instance-variables/plsql/", "name": "flow_plugin_manage_instance_variables.pkb", "add_show_errors": false }


### PR DESCRIPTION
Updated script for generating supporting objects scripts.

- Added new elements for 22.1
- Removed obsolete elements
- Adjusted order of entries with scratch installation (easier maintenance in the future)