### PR TITLE
Fix XML Migration with Variable Expressions

### DIFF
--- a/src/plsql/flow_migrate_xml_pkg.pkb
+++ b/src/plsql/flow_migrate_xml_pkg.pkb
@@ -188,6 +188,9 @@ as
     l_ext_child_node dbms_xmldom.DOMNode;
     l_ext_child_tag_name varchar2(50);
 
+    -- exsiting extensionElements
+    l_old_ext_nodes dbms_xmldom.DOMNodeList;
+
     -- user task
     l_items varchar2(4000);
     l_items_arr apex_t_varchar2;
@@ -196,6 +199,50 @@ as
     l_valid_items number;
 
     l_return clob;
+
+    function get_or_create_ext_elements
+    (
+      p_domdoc  dbms_xmldom.DOMDocument
+    , p_domnode dbms_xmldom.DOMNode
+    , p_elem    dbms_xmldom.DOMElement
+    )
+      return dbms_xmldom.DOMNode
+    as
+      l_new_ext_node     dbms_xmldom.DOMNode;
+      l_cur_ext_elements dbms_xmldom.DOMNodeList;
+    begin
+      l_cur_ext_elements :=
+        dbms_xmldom.getchildrenbytagname
+        (
+          elem => p_elem
+        , name => 'bpmn:extensionElements'
+        , ns   => flow_constants_pkg.gc_nsapex
+        );
+
+      if dbms_xmldom.getlength(l_cur_ext_elements) = 1 then
+        l_new_ext_node := l_cur_ext_elements(1);
+      else
+        -- create extension element node 
+        l_new_ext_node :=
+          dbms_xmldom.makenode( elem => 
+            dbms_xmldom.createelement
+            ( 
+              doc     => p_domdoc
+            , tagName => 'bpmn: extensionElements'
+            , ns      => flow_constants_pkg.gc_nsbpmn
+            )
+          );
+        -- append
+        l_new_ext_node :=
+          dbms_xmldom.appendchild
+          (
+            n        => p_domnode
+          , newchild => l_new_ext_node
+          );
+      end if;
+      return l_new_ext_node;
+    end get_or_create_ext_elements
+    ;
   begin
     -- get xml document
     l_data := XMLTYPE(p_dgrm_content);
@@ -225,19 +272,15 @@ as
             , newValue => 'apexPage'
             , ns => flow_constants_pkg.gc_nsapex
             );
-            -- create extension element node 
-            l_extension_node := dbms_xmldom.makenode( 
-              elem => dbms_xmldom.createelement( 
-                  doc => l_domdoc
-                , tagName => 'bpmn:extensionElements'
-                , ns => flow_constants_pkg.gc_nsbpmn
-                )
-            );
-            -- append
-            l_extension_node := dbms_xmldom.appendchild(
-              n => l_domnode
-            , newchild => l_extension_node
-            );
+
+            l_extension_node :=
+              get_or_create_ext_elements
+              ( 
+                p_domdoc  => l_domdoc
+              , p_domnode => l_domnode
+              , p_elem    => l_domelement
+              );
+
             -- create apex page node 
             l_task_type_node := dbms_xmldom.makenode( 
               elem => dbms_xmldom.createelement( 
@@ -383,19 +426,15 @@ as
               , newValue => 'executePlsql'
               , ns => flow_constants_pkg.gc_nsapex
               );
-              -- create extension element node 
-              l_extension_node := dbms_xmldom.makenode( 
-                elem => dbms_xmldom.createelement( 
-                          doc => l_domdoc
-                        , tagName => 'bpmn:extensionElements'
-                        , ns => flow_constants_pkg.gc_nsbpmn
-                        )
+
+            l_extension_node :=
+              get_or_create_ext_elements
+              ( 
+                p_domdoc  => l_domdoc
+              , p_domnode => l_domnode
+              , p_elem    => l_domelement
               );
-              -- append
-              l_extension_node := dbms_xmldom.appendchild(
-                n => l_domnode
-              , newchild => l_extension_node
-              );
+
               -- create execute Plsql node 
               l_task_type_node := dbms_xmldom.makenode( 
                 elem => dbms_xmldom.createelement( 

--- a/src/plsql/flow_migrate_xml_pkg.pkb
+++ b/src/plsql/flow_migrate_xml_pkg.pkb
@@ -211,16 +211,16 @@ as
       l_new_ext_node     dbms_xmldom.DOMNode;
       l_cur_ext_elements dbms_xmldom.DOMNodeList;
     begin
+        
       l_cur_ext_elements :=
         dbms_xmldom.getchildrenbytagname
         (
           elem => p_elem
-        , name => 'bpmn:extensionElements'
-        , ns   => flow_constants_pkg.gc_nsapex
+        , name => 'extensionElements'
         );
 
-      if dbms_xmldom.getlength(l_cur_ext_elements) = 1 then
-        l_new_ext_node := l_cur_ext_elements(1);
+      if dbms_xmldom.getlength(l_cur_ext_elements) > 0 then
+        l_new_ext_node := dbms_xmldom.item(l_cur_ext_elements, 0);
       else
         -- create extension element node 
         l_new_ext_node :=
@@ -228,8 +228,7 @@ as
             dbms_xmldom.createelement
             ( 
               doc     => p_domdoc
-            , tagName => 'bpmn: extensionElements'
-            , ns      => flow_constants_pkg.gc_nsbpmn
+            , tagName => 'extensionElements'
             )
           );
         -- append


### PR DESCRIPTION
During XML migration a new extensionElements node was created.
This did not take into account that such a node might already exist.
Therefore two extensionElements nodes are present after migration which are then ignored by the modeler.

This change fixes the migration package, a separate hot fix to merge the two nodes if a migration already took place needs to be developed separately.