### PR TITLE
Issues/issue 77 (Case insensitive process variables)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,22 @@
 # Flows for APEX - Changelog
 
+## v22.2
+
+- Adds BPMN Call Activities, allowing a process diagram to call another process diagram, passing and returning in/out variables.
+- Adds scoping to process variables at diagram level to support call activities.
+- Support for timer, escalation, and error boundary events on call activities.
+- Adds support for Oracle APEX Approval Tasks when running with APEX v22.1 and above.  Approvals are called as a type of bpmn:userTask.
+- Adds a Approval Result Return process plug-in for declarative configuration of Approval Tasks.
+- Adds support for Gateway Routing Expressions, defined as part of each forward path from an Inclusive Gateway or Exclusive Gateway.
+- Adds process variable bind syntax (:F4A$myvar) support for Gateway Routing Expressions.
+- Makes processVariable naming case-independant, so that myVar and MYVAR are the same variable.
+- Creates an APEX session for non-APEX originated end points, ensuring that variable expressions, debugging, etc. work correctly from non-APEX API calls, after timers, from test engines, etc.
+- Internally enhances storage of parsed BPMN object attributes using JSON structures in place of the flow_object_attributes table.
+- Simplifies translation framework, allowing contributors to more easily supply translations to be incorporated into the product.
+- Adds new translations to support Brazilian Portuguese (pt-BR), German (de), and Japanese (ja).
+- Enhanced engine testing regime now introduced through utPLSQL regression test suites.
+- Enhanced sample app "Expense Claims" to reflect features added to Flows for APEX v22.2. 
+
 ## v22.1
 
 - Adds repeating timers for non-interrupting boundary events - facilitating repeated reminders.

--- a/src/data/engine_messages_en.json
+++ b/src/data/engine_messages_en.json
@@ -505,6 +505,11 @@
   "text_key" : "apex-task-creation-error",
   "source" : "Error creating APEX Workflow task %0 in application %1.  see debug for details.",
   "target" : "Error creating APEX Workflow task %0 in application %1.  see debug for details."
+},
+{
+  "text_key" : "apex-task-priority-error",
+  "source" : "Error creating APEX Workflow task - invalid priority %0.",
+  "target" : "Error creating APEX Workflow task - invalid priority %0."
 }
 ]
 }

--- a/src/data/engine_messages_fr.json
+++ b/src/data/engine_messages_fr.json
@@ -505,6 +505,11 @@
   "text_key" : "apex-task-creation-error",
   "source" : "Error creating APEX Workflow task %0 in application %1.  see debug for details.",
   "target" : "Error creating APEX Workflow task %0 in application %1.  see debug for details."
+},
+{
+  "text_key" : "apex-task-priority-error",
+  "source" : "Error creating APEX Workflow task - invalid priority %0.",
+  "target" : "Error creating APEX Workflow task - invalid priority %0."
 }
 ]
 }

--- a/src/data/engine_messages_pt.json
+++ b/src/data/engine_messages_pt.json
@@ -462,6 +462,11 @@
     "text_key" : "apex-task-creation-error",
     "source" : "Error creating APEX Workflow task %0 in application %1.  see debug for details.",
     "target" : "Error creating APEX Workflow task %0 in application %1.  see debug for details."
+  },
+  {
+    "text_key" : "apex-task-priority-error",
+    "source" : "Error creating APEX Workflow task - invalid priority %0.",
+    "target" : "Error creating APEX Workflow task - invalid priority %0."
   }
   ]
 }

--- a/src/ddl/install_scratch.sql
+++ b/src/ddl/install_scratch.sql
@@ -332,8 +332,7 @@ create table flow_process_variables
 , prov_var_clob clob
 );
 
-alter table flow_process_variables add constraint prov_pk primary key (prov_prcs_id, prov_scope, prov_var_name);
-
+alter table flow_process_variables add constraint prov_pk primary key (prov_prcs_id, prov_scope, upper(prov_var_name));
 
 alter table flow_process_variables add constraint prov_prcs_fk foreign key (prov_prcs_id)
    references flow_processes (prcs_id)

--- a/src/ddl/install_scratch.sql
+++ b/src/ddl/install_scratch.sql
@@ -332,7 +332,9 @@ create table flow_process_variables
 , prov_var_clob clob
 );
 
-alter table flow_process_variables add constraint prov_pk primary key (prov_prcs_id, prov_scope, upper(prov_var_name));
+alter table flow_process_variables add constraint prov_pk primary key (prov_prcs_id, prov_scope, prov_var_name);
+
+create index prov_uc_pk on flow_process_variables (prov_prcs_id, prov_scope, upper(prov_var_name));
 
 alter table flow_process_variables add constraint prov_prcs_fk foreign key (prov_prcs_id)
    references flow_processes (prcs_id)

--- a/src/ddl/install_scratch.sql
+++ b/src/ddl/install_scratch.sql
@@ -330,11 +330,11 @@ create table flow_process_variables
 , prov_var_num number
 , prov_var_date date
 , prov_var_clob clob
+, prov_var_name_uc varchar2(50 char) generated always as upper(prov_var_name)
 );
 
-alter table flow_process_variables add constraint prov_pk primary key (prov_prcs_id, prov_scope, prov_var_name);
+alter table flow_process_variables add constraint prov_pk primary key (prov_prcs_id, prov_scope, prov_var_name_uc);
 
-create index prov_uc_pk on flow_process_variables (prov_prcs_id, prov_scope, upper(prov_var_name));
 
 alter table flow_process_variables add constraint prov_prcs_fk foreign key (prov_prcs_id)
    references flow_processes (prcs_id)

--- a/src/migrations/22.1_to_22.2/feature-172.sql
+++ b/src/migrations/22.1_to_22.2/feature-172.sql
@@ -119,4 +119,4 @@ PROMPT >> Prepare Process Variables for Scoping
   alter table flow_process_variables
     modify ( prov_scope not null);
 
-  alter table flow_process_variables add constraint prov_pk primary key (prov_prcs_id, prov_scope, prov_var_name);
+ -- NOTE primary key on flow_process_variables is recreated as part of issue-77.sql migration script

--- a/src/migrations/22.1_to_22.2/issue-77.sql
+++ b/src/migrations/22.1_to_22.2/issue-77.sql
@@ -1,0 +1,14 @@
+PROMPT >> Migration for Case-insensitive process variables (issue77)
+
+
+-- 1. BEFORE MIGRATION STARTS, NEED TO CHECK (prov_prcs_id, prov_scope, upper (prov_var_name)) IS UNIQUE
+
+-- 2. ADDING THE NEW INDEX NEEDS TO RUN AFTER feature-172.sql (which creates the PK including prov_scope)
+
+-- 3.  NOT YET TESTED!
+
+alter table flow_process_variables drop primary key;
+
+create unique index on flow_process_variables (prov_prcs_id, prov_scope, upper (prov_var_name));
+
+/

--- a/src/migrations/22.1_to_22.2/issue-77.sql
+++ b/src/migrations/22.1_to_22.2/issue-77.sql
@@ -1,19 +1,8 @@
 PROMPT >> Migration for Case-insensitive process variables (issue77)
 
-
 -- 1. BEFORE MIGRATION STARTS, NEED TO CHECK (prov_prcs_id, prov_scope, upper (prov_var_name)) IS UNIQUE
-
--- 2. ADDING THE NEW INDEX NEEDS TO RUN AFTER feature-172.sql (which creates the PK including prov_scope)
-
--- 3.  NOT YET TESTED!
-
-alter table flow_process_variables drop primary key;
+-- 2. NEEDS TO RUN AFTER feature-172.sql (which creates prov_scope column)
 
 alter table flow_process_variables add (prov_var_name_uc varchar2(50 char) generated always as upper(prov_var_name));
-
+alter table flow_process_variables drop primary key;
 alter table flow_process_variables add constraint prov_pk primary key (prov_prcs_id, prov_scope, prov_var_name_uc);
-
-
-create unique index on flow_process_variables (prov_prcs_id, prov_scope, upper (prov_var_name));
-
-/

--- a/src/migrations/22.1_to_22.2/issue-77.sql
+++ b/src/migrations/22.1_to_22.2/issue-77.sql
@@ -9,6 +9,11 @@ PROMPT >> Migration for Case-insensitive process variables (issue77)
 
 alter table flow_process_variables drop primary key;
 
+alter table flow_process_variables add (prov_var_name_uc varchar2(50 char) generated always as upper(prov_var_name));
+
+alter table flow_process_variables add constraint prov_pk primary key (prov_prcs_id, prov_scope, prov_var_name_uc);
+
+
 create unique index on flow_process_variables (prov_prcs_id, prov_scope, upper (prov_var_name));
 
 /

--- a/src/migrations/22.1_to_22.2/migrate.sql
+++ b/src/migrations/22.1_to_22.2/migrate.sql
@@ -19,6 +19,7 @@ PROMPT >> Halt DBMS_SCHEDULER job
 @@feature-172.sql
 @@issue-444.sql
 @@feature-468.sql
+@@issue-77.sql
 @@set_flows_version.sql
 
 

--- a/src/plsql/flow_constants_pkg.pks
+++ b/src/plsql/flow_constants_pkg.pks
@@ -231,7 +231,6 @@ as
   -- Standard Process Variable Suffixes
 
   gc_prov_suffix_task_id              constant  varchar2(50 char) := ':task_id';
-  gc_prov_suffix_result               constant  varchar2(50 char) := ':result';
   gc_prov_suffix_route                constant  varchar2(50 char) := ':route';  
 
   -- Process Variable and Gateway Routing Variable Expression Types

--- a/src/plsql/flow_gateways.pkb
+++ b/src/plsql/flow_gateways.pkb
@@ -275,7 +275,7 @@ as
                         , p0 => l_routing_variable
                         );                                                                
       else 
-        apex_debug.info( p_message => '-- Using Gateway Route Expressions.' );
+        apex_debug.info( p_message => '-- Using Gateway Route Expressions or Default Routing.' );
         -- look for gateway routing expressions or default routing
         l_forward_routes := get_valid_routing_expression_routes ( pi_prcs_id          => pi_prcs_id
                                                                 , pi_sbfl_id          => pi_sbfl_id

--- a/src/plsql/flow_proc_vars_int.pkb
+++ b/src/plsql/flow_proc_vars_int.pkb
@@ -60,11 +60,11 @@ begin
     when dup_val_on_index then
       l_action := 'var-update-error';
       update flow_process_variables prov 
-         set prov.prov_var_vc2  = pi_vc2_value
-       where prov.prov_prcs_id  = pi_prcs_id
-         and prov.prov_scope    = pi_scope
-         and prov.prov_var_name = pi_var_name
-         and prov.prov_var_type = flow_constants_pkg.gc_prov_var_type_varchar2 
+         set prov.prov_var_vc2          = pi_vc2_value
+       where prov.prov_prcs_id          = pi_prcs_id
+         and prov.prov_scope            = pi_scope
+         and upper(prov.prov_var_name)  = upper(pi_var_name)
+         and prov.prov_var_type         = flow_constants_pkg.gc_prov_var_type_varchar2 
            ;
     when others
     then
@@ -126,11 +126,11 @@ begin
     when dup_val_on_index then
       l_action := 'var-update-error';
       update flow_process_variables prov 
-         set prov.prov_var_num  = pi_num_value
-       where prov.prov_prcs_id  = pi_prcs_id
-         and prov.prov_scope    = pi_scope
-         and prov.prov_var_name = pi_var_name
-         and prov.prov_var_type = flow_constants_pkg.gc_prov_var_type_number
+         set prov.prov_var_num          = pi_num_value
+       where prov.prov_prcs_id          = pi_prcs_id
+         and prov.prov_scope            = pi_scope
+         and upper(prov.prov_var_name)  = upper(pi_var_name)
+         and prov.prov_var_type         = flow_constants_pkg.gc_prov_var_type_number
            ;
     when others
     then
@@ -192,11 +192,11 @@ begin
     when dup_val_on_index then
       l_action := 'var-update-error';
       update flow_process_variables prov 
-         set prov.prov_var_date = pi_date_value
-       where prov.prov_prcs_id  = pi_prcs_id
-         and prov.prov_scope    = pi_scope
-         and prov.prov_var_name = pi_var_name
-         and prov.prov_var_type = flow_constants_pkg.gc_prov_var_type_date
+         set prov.prov_var_date         = pi_date_value
+       where prov.prov_prcs_id          = pi_prcs_id
+         and prov.prov_scope            = pi_scope
+         and upper(prov.prov_var_name)  = upper(pi_var_name)
+         and prov.prov_var_type         = flow_constants_pkg.gc_prov_var_type_date
            ;
     when others
     then
@@ -257,11 +257,11 @@ begin
   exception
     when dup_val_on_index then
       update flow_process_variables prov 
-         set prov.prov_var_clob = pi_clob_value
-       where prov.prov_prcs_id  = pi_prcs_id
-         and prov.prov_scope    = pi_scope
-         and prov.prov_var_name = pi_var_name
-         and prov.prov_var_type = flow_constants_pkg.gc_prov_var_type_clob
+         set prov.prov_var_clob          = pi_clob_value
+       where prov.prov_prcs_id           = pi_prcs_id
+         and prov.prov_scope             = pi_scope
+         and upper(prov.prov_var_name)   = upper(pi_var_name)
+         and prov.prov_var_type          = flow_constants_pkg.gc_prov_var_type_clob
            ;
     when others
     then
@@ -306,9 +306,9 @@ begin
    select prov.prov_var_vc2
      into po_vc2_value
      from flow_process_variables prov
-    where prov.prov_prcs_id = pi_prcs_id
-      and prov.prov_var_name = pi_var_name
-      and prov.prov_scope = pi_scope
+    where prov.prov_prcs_id         = pi_prcs_id
+      and upper(prov.prov_var_name) = upper(pi_var_name)
+      and prov.prov_scope           = pi_scope
         ;
    return po_vc2_value;
 exception
@@ -339,8 +339,8 @@ begin
    select prov.prov_var_num
      into po_num_value
      from flow_process_variables prov
-    where prov.prov_prcs_id = pi_prcs_id
-      and prov.prov_var_name = pi_var_name
+    where prov.prov_prcs_id         = pi_prcs_id
+      and upper(prov.prov_var_name) = upper(pi_var_name)
         ;
    return po_num_value;
 exception
@@ -371,8 +371,8 @@ begin
    select prov.prov_var_date
      into po_date_value
      from flow_process_variables prov
-    where prov.prov_prcs_id = pi_prcs_id
-      and prov.prov_var_name = pi_var_name
+    where prov.prov_prcs_id         = pi_prcs_id
+      and upper(prov.prov_var_name) = upper(pi_var_name)
         ;
    return po_date_value;
 exception
@@ -403,8 +403,8 @@ begin
    select prov.prov_var_clob
      into po_clob_value
      from flow_process_variables prov
-    where prov.prov_prcs_id = pi_prcs_id
-      and prov.prov_var_name = pi_var_name
+    where prov.prov_prcs_id         = pi_prcs_id
+      and upper(prov.prov_var_name) = upper(pi_var_name)
         ;
    return po_clob_value;
 exception
@@ -437,9 +437,9 @@ begin
    select prov.prov_var_type
      into l_var_type
      from flow_process_variables prov
-    where prov.prov_prcs_id   = pi_prcs_id
-      and prov.prov_var_name  = pi_var_name
-      and prov.prov_scope     = pi_scope
+    where prov.prov_prcs_id           = pi_prcs_id
+      and upper(prov.prov_var_name)   = upper(pi_var_name)
+      and prov.prov_scope             = pi_scope
         ;
    return l_var_type;
 exception
@@ -471,16 +471,16 @@ begin
   select prov_var_type
     into l_var_type
     from flow_process_variables prov
-   where prov.prov_prcs_id = pi_prcs_id
-     and prov.prov_var_name = pi_var_name
-     and prov.prov_scope = pi_scope
+   where prov.prov_prcs_id          = pi_prcs_id
+     and upper(prov.prov_var_name)  = upper(pi_var_name)
+     and prov.prov_scope            = pi_scope
      for update wait 2;
 
   delete 
     from flow_process_variables prov
-   where prov.prov_prcs_id  = pi_prcs_id
-     and prov.prov_var_name = pi_var_name
-     and prov.prov_scope    = pi_scope
+   where prov.prov_prcs_id          = pi_prcs_id
+     and upper(prov.prov_var_name)  = upper(pi_var_name)
+     and prov.prov_scope            = pi_scope
   ;
   flow_logging.log_variable_event
   ( p_process_id        => pi_prcs_id
@@ -540,9 +540,9 @@ end delete_var;
   is 
   begin
     return get_var_vc2 
-           ( pi_prcs_id => pi_prcs_id
+           ( pi_prcs_id  => pi_prcs_id
            , pi_var_name => flow_constants_pkg.gc_prov_builtin_business_ref
-           , pi_scope => pi_scope
+           , pi_scope    => pi_scope
            );
   end get_business_ref;
 
@@ -616,9 +616,9 @@ end delete_var;
               select prov.prov_var_vc2
                 into l_replacement_value
                 from flow_process_variables prov
-               where prov.prov_prcs_id  = pi_prcs_id
-                 and prov.prov_scope    = pi_scope
-                 and upper(prov.prov_var_name) = upper(l_f4a_substitutions(i))
+               where prov.prov_prcs_id          = pi_prcs_id
+                 and prov.prov_scope            = pi_scope
+                 and upper(prov.prov_var_name)  = upper(l_f4a_substitutions(i))
               ;
               pio_string := replace( pio_string, get_replacement_pattern( l_f4a_substitutions(i) ), l_replacement_value );
             exception
@@ -683,9 +683,9 @@ end delete_var;
               select prov.prov_var_vc2
                 into l_replacement_value
                 from flow_process_variables prov
-               where prov.prov_prcs_id  = pi_prcs_id
-                 and prov.prov_scope    = pi_scope
-                 and upper(prov.prov_var_name) = upper(l_f4a_substitutions(i))
+               where prov.prov_prcs_id          = pi_prcs_id
+                 and prov.prov_scope            = pi_scope
+                 and upper(prov.prov_var_name)  = upper(l_f4a_substitutions(i))
               ;
               pio_string := replace( pio_string, get_replacement_pattern( l_f4a_substitutions(i) ), l_replacement_value );
             exception

--- a/src/plsql/flow_process_vars.pks
+++ b/src/plsql/flow_process_vars.pks
@@ -1,4 +1,6 @@
-/* 
+create or replace package flow_process_vars
+  authid definer
+as /* 
 -- Flows for APEX - flow_process_vars.pkb
 -- 
 -- (c) Copyright Oracle Corporation and / or its affiliates, 2022.
@@ -15,9 +17,6 @@
 **
 */ 
  
-create or replace package flow_process_vars
-  authid definer
-as 
 /**
 PROCESS VARIABLE SYSTEM API
 ===========================

--- a/src/plsql/flow_timers_pkg.pkb
+++ b/src/plsql/flow_timers_pkg.pkb
@@ -453,7 +453,7 @@ as
                 l_parsed_ts := to_timestamp_tz ( flow_proc_vars_int.get_var_vc2
                                                  ( pi_prcs_id  => pi_prcs_id
                                                  , pi_var_name => substr  ( l_timer_def.timer_definition,6
-                                                                          , length(l_timer_def.timer_definition)-6
+                                                                        , length(l_timer_def.timer_definition)-6
                                                                           )
                                                  , pi_scope    => l_scope
                                                  )
@@ -554,8 +554,8 @@ as
                 l_parsed_ts := to_timestamp_tz ( flow_proc_vars_int.get_var_vc2
                                                   ( pi_prcs_id  => pi_prcs_id
                                                   , pi_var_name => substr  ( l_timer_def.oracle_date,6
-                                                                           , length(l_timer_def.oracle_date)-6
-                                                                           )
+                                                                                    , length(l_timer_def.oracle_date)-6
+                                                                                    )
                                                   , pi_scope    => l_scope
                                                   )
                                                 , l_timer_def.oracle_format_mask
@@ -578,7 +578,7 @@ as
                                              , pi_scope   => l_scope
                                              );
           l_parsed_duration_ds := to_dsinterval ( nvl ( l_timer_def.oracle_duration_ds , '000 00:00:00') );
-          l_parsed_duration_ym := to_yminterval ( nvl( l_timer_def.oracle_duration_ym, '0-0') );
+          l_parsed_duration_ym := to_yminterval ( nvl ( l_timer_def.oracle_duration_ym, '0-0') );
           l_parsed_ts := systimestamp + l_parsed_duration_ym + l_parsed_duration_ds;
 
         when flow_constants_pkg.gc_timer_type_oracle_cycle then

--- a/src/plsql/flow_usertask_pkg.pkb
+++ b/src/plsql/flow_usertask_pkg.pkb
@@ -302,7 +302,7 @@ as
       apex_debug.enter
       (p_routine_name => 'return_approval_result'
       );
-      -- check task belongs to this process
+      -- check task belongs to this process by looking for a process variable with content = task id and name ending in task id suffix.
       begin
         select prov.prov_var_name
              , replace (prov.prov_var_name , flow_constants_pkg.gc_prov_suffix_task_id) l_potential_current

--- a/src/views/engine-app/flow_p0008_subflows_debug_vw.sql
+++ b/src/views/engine-app/flow_p0008_subflows_debug_vw.sql
@@ -37,6 +37,7 @@ as
              when 'waiting at gateway' then 'fa fa-hand-stop-o'
              when 'waiting for timer' then 'fa fa-clock-o'
              when 'waiting for event' then 'fa fa-hand-stop-o'
+             when 'waiting for approval' then 'fa fa-question-square-o'
          end as sbfl_status_icon
        , sbfl.sbfl_reservation
        , null as actions   

--- a/src/views/engine-app/flow_p0008_subflows_vw.sql
+++ b/src/views/engine-app/flow_p0008_subflows_vw.sql
@@ -27,6 +27,7 @@ as
              when 'waiting at gateway' then 'fa fa-hand-stop-o'
              when 'waiting for timer' then 'fa fa-clock-o'
              when 'waiting for event' then 'fa fa-hand-stop-o'
+             when 'waiting for approval' then 'fa fa-question-square-o'
          end as sbfl_status_icon
        , sbfl.timr_start_on at time zone sessiontimezone as sbfl_timr_start_on
        , sbfl.sbfl_current_lane_name as sbfl_current_lane

--- a/test/models/A04a - Basic Model_0.bpmn
+++ b/test/models/A04a - Basic Model_0.bpmn
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1wzb475" targetNamespace="http://bpmn.io/schema/b" exporter="Flows for APEX" exporterVersion="22.1.0">
+  <bpmn:process id="Process_0rxermh" isExecutable="false">
+    <bpmn:startEvent id="Start" name="Start">
+      <bpmn:outgoing>Flow_0e7q139</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="A" name="A">
+      <bpmn:incoming>Flow_0e7q139</bpmn:incoming>
+      <bpmn:outgoing>Flow_0i5wcjm</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0e7q139" sourceRef="Start" targetRef="A" />
+    <bpmn:task id="B" name="B">
+      <bpmn:incoming>Flow_0i5wcjm</bpmn:incoming>
+      <bpmn:outgoing>Flow_0e53n28</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0i5wcjm" sourceRef="A" targetRef="B" />
+    <bpmn:endEvent id="End" name="End">
+      <bpmn:incoming>Flow_0e53n28</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0e53n28" sourceRef="B" targetRef="End" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0rxermh">
+      <bpmndi:BPMNEdge id="Flow_0e7q139_di" bpmnElement="Flow_0e7q139">
+        <di:waypoint x="208" y="260" />
+        <di:waypoint x="310" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0i5wcjm_di" bpmnElement="Flow_0i5wcjm">
+        <di:waypoint x="410" y="260" />
+        <di:waypoint x="490" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0e53n28_di" bpmnElement="Flow_0e53n28">
+        <di:waypoint x="590" y="260" />
+        <di:waypoint x="682" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0fhqg78_di" bpmnElement="Start">
+        <dc:Bounds x="172" y="242" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="178" y="285" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ajtv1q_di" bpmnElement="A">
+        <dc:Bounds x="310" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ky6p0n_di" bpmnElement="B">
+        <dc:Bounds x="490" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0wbyjbg_di" bpmnElement="End">
+        <dc:Bounds x="682" y="242" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="691" y="285" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/models/import.json
+++ b/test/models/import.json
@@ -119,6 +119,13 @@
         "file": "A03h - Model with one start event with bad before-event var exp_0.bpmn"
     },
     {
+        "dgrm_name": "A04a - Basic Model",
+        "dgrm_version": "0",
+        "dgrm_status": "draft",
+        "dgrm_category": "Testing",
+        "file": "A04a - Basic Model_0.bpmn"
+    },
+    {
         "dgrm_name": "A10 - Variable Expressions Types",
         "dgrm_version": "0",
         "dgrm_status": "draft",

--- a/test/plsql/test_002_gateway.pkb
+++ b/test/plsql/test_002_gateway.pkb
@@ -179,8 +179,15 @@ create or replace package body test_002_gateway is
       ut.expect( l_actual ).to_equal( l_expected );
    end;
 
-
-   procedure exclusive_route_provided
+   procedure exclusive_route_provided_runner
+   ( pi_prcs_name    in flow_processes.prcs_name%type
+   , pi_routing_var_name_A   in varchar2
+   , pi_routing_value_A      in varchar2
+   , pi_routing_var_name_B   in varchar2
+   , pi_routing_value_B      in varchar2
+   , pi_routing_var_name_C   in varchar2
+   , pi_routing_value_C      in varchar2
+   )
    is
       l_prcs_id  flow_processes.prcs_id%type;
       l_dgrm_id  flow_diagrams.dgrm_id%type;
@@ -195,15 +202,15 @@ create or replace package body test_002_gateway is
       -- create a new instance
       l_prcs_id := flow_api_pkg.flow_create(
            pi_dgrm_id   => l_dgrm_id
-         , pi_prcs_name => 'test - exclusive_route_provided'
+         , pi_prcs_name => pi_prcs_name 
       );
       g_prcs_id_3 := l_prcs_id;
 
       --Set RouteA
       flow_process_vars.set_var(
            pi_prcs_id   => l_prcs_id
-         , pi_var_name  => 'Exclusive:route'
-         , pi_vc2_value => 'RouteA'
+         , pi_var_name  =>  pi_routing_var_name_A
+         , pi_vc2_value =>  pi_routing_value_A
       );
 
       flow_api_pkg.flow_start( p_process_id => l_prcs_id );
@@ -211,7 +218,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - exclusive_route_provided' as prcs_name, 
+            pi_prcs_name  as prcs_name, 
             flow_constants_pkg.gc_prcs_status_running as prcs_status 
          from dual;
 
@@ -247,7 +254,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - exclusive_route_provided' as prcs_name, 
+            pi_prcs_name  as prcs_name, 
             flow_constants_pkg.gc_prcs_status_completed as prcs_status 
          from dual;
 
@@ -261,8 +268,8 @@ create or replace package body test_002_gateway is
       --Set RouteB
       flow_process_vars.set_var(
            pi_prcs_id   => l_prcs_id
-         , pi_var_name  => 'Exclusive:route'
-         , pi_vc2_value => 'RouteB'
+         , pi_var_name  => pi_routing_var_name_B
+         , pi_vc2_value => pi_routing_value_B
       );
 
       flow_api_pkg.flow_start( p_process_id => l_prcs_id );
@@ -270,7 +277,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - exclusive_route_provided' as prcs_name, 
+            pi_prcs_name  as prcs_name, 
             flow_constants_pkg.gc_prcs_status_running as prcs_status 
          from dual;
 
@@ -306,7 +313,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - exclusive_route_provided' as prcs_name, 
+            pi_prcs_name  as prcs_name, 
             flow_constants_pkg.gc_prcs_status_completed as prcs_status 
          from dual;
 
@@ -320,8 +327,8 @@ create or replace package body test_002_gateway is
       --Set RouteC
       flow_process_vars.set_var(
            pi_prcs_id   => l_prcs_id
-         , pi_var_name  => 'Exclusive:route'
-         , pi_vc2_value => 'RouteC'
+         , pi_var_name  => pi_routing_var_name_C
+         , pi_vc2_value =>  pi_routing_value_C
       );
 
       flow_api_pkg.flow_start( p_process_id => l_prcs_id );
@@ -329,7 +336,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - exclusive_route_provided' as prcs_name, 
+            pi_prcs_name  as prcs_name, 
             flow_constants_pkg.gc_prcs_status_running as prcs_status 
          from dual;
 
@@ -365,7 +372,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - exclusive_route_provided' as prcs_name, 
+            pi_prcs_name  as prcs_name, 
             flow_constants_pkg.gc_prcs_status_completed as prcs_status 
          from dual;
 
@@ -374,7 +381,50 @@ create or replace package body test_002_gateway is
 
       ut.expect( l_actual ).to_equal( l_expected );
 
-   end;
+   end exclusive_route_provided_runner;
+
+
+   procedure exclusive_route_provided_correct_case
+   is
+   begin
+      exclusive_route_provided_runner 
+      ( pi_prcs_name             => 'test - exclusive_route_provided - matching case'
+      , pi_routing_var_name_A    => 'Exclusive:route'
+      , pi_routing_value_A       => 'RouteA'
+      , pi_routing_var_name_B    => 'Exclusive:route'
+      , pi_routing_value_B       => 'RouteB'
+      , pi_routing_var_name_C    => 'Exclusive:route'
+      , pi_routing_value_C       => 'RouteC'
+      );
+   end exclusive_route_provided_correct_case;
+
+   procedure exclusive_route_provided_upper_case
+   is
+   begin
+      exclusive_route_provided_runner 
+      ( pi_prcs_name             => 'test - exclusive_route_provided - upper case'
+      , pi_routing_var_name_A    => 'EXCLUSIVE:ROUTE'
+      , pi_routing_value_A       => 'RouteA'
+      , pi_routing_var_name_B    => 'EXCLUSIVE:ROUTE'
+      , pi_routing_value_B       => 'RouteB'
+      , pi_routing_var_name_C    => 'EXCLUSIVE:ROUTE'
+      , pi_routing_value_C       => 'RouteC'
+      );
+   end exclusive_route_provided_upper_case;
+
+   procedure exclusive_route_provided_lower_case
+   is
+   begin
+      exclusive_route_provided_runner 
+      ( pi_prcs_name             => 'test - exclusive_route_provided - lower case'
+      , pi_routing_var_name_A    => 'exclusive:route'
+      , pi_routing_value_A       => 'RouteA'
+      , pi_routing_var_name_B    => 'exclusive:route'
+      , pi_routing_value_B       => 'RouteB'
+      , pi_routing_var_name_C    => 'exclusive:route'
+      , pi_routing_value_C       => 'RouteC'
+      );
+   end exclusive_route_provided_lower_case;
 
    procedure inclusive_no_route
    is
@@ -518,7 +568,23 @@ create or replace package body test_002_gateway is
       ut.expect( l_actual ).to_equal( l_expected );
    end;
 
-   procedure inclusive_route_provided
+   procedure inclusive_route_provided_runner
+   ( pi_prcs_name            in flow_processes.prcs_name%type
+   , pi_routing_var_name_A   in varchar2
+   , pi_routing_value_A      in varchar2
+   , pi_routing_var_name_B   in varchar2
+   , pi_routing_value_B      in varchar2
+   , pi_routing_var_name_C   in varchar2
+   , pi_routing_value_C      in varchar2
+   , pi_routing_var_name_AB  in varchar2
+   , pi_routing_value_AB     in varchar2
+   , pi_routing_var_name_BC  in varchar2
+   , pi_routing_value_BC     in varchar2
+   , pi_routing_var_name_AC  in varchar2
+   , pi_routing_value_AC     in varchar2
+   , pi_routing_var_name_ABC in varchar2
+   , pi_routing_value_ABC    in varchar2   
+   )  
    is
       l_prcs_id  flow_processes.prcs_id%type;
       l_dgrm_id  flow_diagrams.dgrm_id%type;
@@ -533,15 +599,15 @@ create or replace package body test_002_gateway is
       -- create a new instance
       l_prcs_id := flow_api_pkg.flow_create(
            pi_dgrm_id => l_dgrm_id
-         , pi_prcs_name => 'test - inclusive_route_provided'
+         , pi_prcs_name => pi_prcs_name
       );
       g_prcs_id_6 := l_prcs_id;
 
       --Set RouteA
       flow_process_vars.set_var(
            pi_prcs_id   => l_prcs_id
-         , pi_var_name  => 'Inclusive:route'
-         , pi_vc2_value => 'RouteA'
+         , pi_var_name  => pi_routing_var_name_A
+         , pi_vc2_value => pi_routing_value_A
       );
 
       flow_api_pkg.flow_start( p_process_id => l_prcs_id );
@@ -549,7 +615,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_running as prcs_status 
          from dual;
 
@@ -593,7 +659,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_completed as prcs_status 
          from dual;
 
@@ -607,8 +673,8 @@ create or replace package body test_002_gateway is
       --Set RouteB
       flow_process_vars.set_var(
            pi_prcs_id   => l_prcs_id
-         , pi_var_name  => 'Inclusive:route'
-         , pi_vc2_value => 'RouteB'
+         , pi_var_name  => pi_routing_var_name_B
+         , pi_vc2_value => pi_routing_value_B 
       );
 
       flow_api_pkg.flow_start( p_process_id => l_prcs_id );
@@ -616,7 +682,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_running as prcs_status 
          from dual;
 
@@ -660,7 +726,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_completed as prcs_status 
          from dual;
 
@@ -674,8 +740,8 @@ create or replace package body test_002_gateway is
       --Set RouteC
       flow_process_vars.set_var(
            pi_prcs_id   => l_prcs_id
-         , pi_var_name  => 'Inclusive:route'
-         , pi_vc2_value => 'RouteC'
+         , pi_var_name  => pi_routing_var_name_C
+         , pi_vc2_value => pi_routing_value_C
       );
 
       flow_api_pkg.flow_start( p_process_id => l_prcs_id );
@@ -683,7 +749,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_running as prcs_status 
          from dual;
 
@@ -727,7 +793,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_completed as prcs_status 
          from dual;
 
@@ -741,8 +807,8 @@ create or replace package body test_002_gateway is
       --Set RouteA:RouteB
       flow_process_vars.set_var(
            pi_prcs_id   => l_prcs_id
-         , pi_var_name  => 'Inclusive:route'
-         , pi_vc2_value => 'RouteA:RouteB'
+         , pi_var_name  => pi_routing_var_name_AB
+         , pi_vc2_value => pi_routing_value_AB
       );
 
       flow_api_pkg.flow_start( p_process_id => l_prcs_id );
@@ -750,7 +816,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_running as prcs_status 
          from dual;
 
@@ -842,7 +908,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_completed as prcs_status 
          from dual;
 
@@ -856,8 +922,8 @@ create or replace package body test_002_gateway is
       --Set RouteA:RouteC
       flow_process_vars.set_var(
            pi_prcs_id   => l_prcs_id
-         , pi_var_name  => 'Inclusive:route'
-         , pi_vc2_value => 'RouteA:RouteC'
+         , pi_var_name  => pi_routing_var_name_AC
+         , pi_vc2_value => pi_routing_value_AC 
       );
 
       flow_api_pkg.flow_start( p_process_id => l_prcs_id );
@@ -865,7 +931,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_running as prcs_status 
          from dual;
 
@@ -957,7 +1023,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_completed as prcs_status 
          from dual;
 
@@ -971,8 +1037,8 @@ create or replace package body test_002_gateway is
       --Set RouteB:RouteC
       flow_process_vars.set_var(
            pi_prcs_id   => l_prcs_id
-         , pi_var_name  => 'Inclusive:route'
-         , pi_vc2_value => 'RouteB:RouteC'
+         , pi_var_name  => pi_routing_var_name_BC
+         , pi_vc2_value => pi_routing_value_BC
       );
 
       flow_api_pkg.flow_start( p_process_id => l_prcs_id );
@@ -980,7 +1046,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_running as prcs_status 
          from dual;
 
@@ -1072,7 +1138,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_completed as prcs_status 
          from dual;
 
@@ -1086,8 +1152,8 @@ create or replace package body test_002_gateway is
       --Set RouteA:RouteB:RouteC
       flow_process_vars.set_var(
            pi_prcs_id   => l_prcs_id
-         , pi_var_name  => 'Inclusive:route'
-         , pi_vc2_value => 'RouteA:RouteB:RouteC'
+         , pi_var_name  => pi_routing_var_name_ABC
+         , pi_vc2_value => pi_routing_value_ABC
       );
 
       flow_api_pkg.flow_start( p_process_id => l_prcs_id );
@@ -1095,7 +1161,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_running as prcs_status 
          from dual;
 
@@ -1248,7 +1314,7 @@ create or replace package body test_002_gateway is
       open l_expected for
          select 
             l_dgrm_id as prcs_dgrm_id, 
-            'test - inclusive_route_provided' as prcs_name, 
+            pi_prcs_name as prcs_name, 
             flow_constants_pkg.gc_prcs_status_completed as prcs_status 
          from dual;
 
@@ -1256,7 +1322,95 @@ create or replace package body test_002_gateway is
          select prcs_dgrm_id, prcs_name, prcs_status from flow_processes where prcs_id = l_prcs_id;
 
       ut.expect( l_actual ).to_equal( l_expected );
-   end;
+   end inclusive_route_provided_runner;
+
+   procedure inclusive_route_provided_correct_case
+   is
+   begin
+      inclusive_route_provided_runner 
+      ( pi_prcs_name             => 'test - inclusive_route_provided - matching case'
+      , pi_routing_var_name_A    => 'Inclusive:route'
+      , pi_routing_value_A       => 'RouteA'
+      , pi_routing_var_name_B    => 'Inclusive:route'
+      , pi_routing_value_B       => 'RouteB'
+      , pi_routing_var_name_C    => 'Inclusive:route'
+      , pi_routing_value_C       => 'RouteC'
+      , pi_routing_var_name_AB   => 'Inclusive:route'
+      , pi_routing_value_AB      => 'RouteA:RouteB'
+      , pi_routing_var_name_BC   => 'Inclusive:route'
+      , pi_routing_value_BC      => 'RouteB:RouteC'
+      , pi_routing_var_name_AC   => 'Inclusive:route'
+      , pi_routing_value_AC      => 'RouteA:RouteC'
+      , pi_routing_var_name_ABC  => 'Inclusive:route'
+      , pi_routing_value_ABC     => 'RouteA:RouteB:RouteC'
+      );
+   end inclusive_route_provided_correct_case;
+
+   procedure inclusive_route_provided_upper_case
+   is
+   begin
+      inclusive_route_provided_runner 
+      ( pi_prcs_name             => 'test - inclusive_route_provided - upper case'
+      , pi_routing_var_name_A    => 'INCLUSIVE:ROUTE'
+      , pi_routing_value_A       => 'RouteA'
+      , pi_routing_var_name_B    => 'INCLUSIVE:ROUTE'
+      , pi_routing_value_B       => 'RouteB'
+      , pi_routing_var_name_C    => 'INCLUSIVE:ROUTE'
+      , pi_routing_value_C       => 'RouteC'
+      , pi_routing_var_name_AB   => 'INCLUSIVE:ROUTE'
+      , pi_routing_value_AB      => 'RouteA:RouteB'
+      , pi_routing_var_name_BC   => 'INCLUSIVE:ROUTE'
+      , pi_routing_value_BC      => 'RouteB:RouteC'
+      , pi_routing_var_name_AC   => 'INCLUSIVE:ROUTE'
+      , pi_routing_value_AC      => 'RouteA:RouteC'
+      , pi_routing_var_name_ABC  => 'INCLUSIVE:ROUTE'
+      , pi_routing_value_ABC     => 'RouteA:RouteB:RouteC'
+      );
+   end inclusive_route_provided_upper_case;
+
+   procedure inclusive_route_provided_lower_case
+   is
+   begin
+      inclusive_route_provided_runner 
+      ( pi_prcs_name             => 'test - inclusive_route_provided - lower case'
+      , pi_routing_var_name_A    => 'inclusive:route'
+      , pi_routing_value_A       => 'RouteA'
+      , pi_routing_var_name_B    => 'inclusive:route'
+      , pi_routing_value_B       => 'RouteB'
+      , pi_routing_var_name_C    => 'inclusive:route'
+      , pi_routing_value_C       => 'RouteC'
+      , pi_routing_var_name_AB   => 'inclusive:route'
+      , pi_routing_value_AB      => 'RouteA:RouteB'
+      , pi_routing_var_name_BC   => 'inclusive:route'
+      , pi_routing_value_BC      => 'RouteB:RouteC'
+      , pi_routing_var_name_AC   => 'inclusive:route'
+      , pi_routing_value_AC      => 'RouteA:RouteC'
+      , pi_routing_var_name_ABC  => 'inclusive:route'
+      , pi_routing_value_ABC     => 'RouteA:RouteB:RouteC'
+      );
+   end inclusive_route_provided_lower_case;
+
+   procedure inclusive_route_provided_jumbled_case
+   is
+   begin
+      inclusive_route_provided_runner 
+      ( pi_prcs_name             => 'test - inclusive_route_provided - jumbled case'
+      , pi_routing_var_name_A    => 'iNcLuSive:RouTe'
+      , pi_routing_value_A       => 'RouteA'
+      , pi_routing_var_name_B    => 'iNcLuSive:RouTe'
+      , pi_routing_value_B       => 'RouteB'
+      , pi_routing_var_name_C    => 'iNcLuSive:RouTe'
+      , pi_routing_value_C       => 'RouteC'
+      , pi_routing_var_name_AB   => 'iNcLuSive:RouTe'
+      , pi_routing_value_AB      => 'RouteA:RouteB'
+      , pi_routing_var_name_BC   => 'iNcLuSive:RouTe'
+      , pi_routing_value_BC      => 'RouteB:RouteC'
+      , pi_routing_var_name_AC   => 'iNcLuSive:RouTe'
+      , pi_routing_value_AC      => 'RouteA:RouteC'
+      , pi_routing_var_name_ABC  => 'iNcLuSive:RouTe'
+      , pi_routing_value_ABC     => 'RouteA:RouteB:RouteC'
+      );
+   end inclusive_route_provided_jumbled_case;
 
    procedure parallel
    is

--- a/test/plsql/test_002_gateway.pks
+++ b/test/plsql/test_002_gateway.pks
@@ -13,28 +13,43 @@ create or replace package test_002_gateway is
 
    -- Need to add tests for completing order
 
-   --%test
+   --%test(a. exclusive gateway - no route provided)
    procedure exclusive_no_route;
 
-   --%test
+   --%test(b. exclusive gateway - default routing)
    procedure exclusive_default;
 
-   --%test
-   procedure exclusive_route_provided;
+   --%test(c1. exclusive gateway - GR var provided - matching case)
+   procedure exclusive_route_provided_correct_case;
 
-   --%test
+   --%test(c2. exclusive gateway - GR var provided - UPPER CASE)
+   procedure exclusive_route_provided_upper_CASE;
+
+   --%test(c3. exclusive gateway - GR var provided - lower CASE)
+   procedure exclusive_route_provided_lower_case;
+
+   --%test(d. inclusive gateway - no routing)
    procedure inclusive_no_route;
 
-   --%test
+   --%test(e. inclusive gateway - default routing)
    procedure inclusive_default;
 
-   --%test
-   procedure inclusive_route_provided;
+   --%test(f1. inclusive gateway - GR provided - matching case)
+   procedure inclusive_route_provided_correct_case;
 
-   --%test
+   --%test(f2. inclusive gateway - GR var provided - UPPER CASE)
+   procedure inclusive_route_provided_upper_CASE;
+
+   --%test(f3. inclusive gateway - GR var provided - lower CASE)
+   procedure inclusive_route_provided_lower_case;
+
+   --%test(f4. inclusive gateway - GR var provided - jumbled CASE)
+   procedure inclusive_route_provided_jumbled_case;
+
+   --%test(g. parallel gateway)
    procedure parallel;
 
-   --%test
+   --%test (h. event based gateway - uses timer)
    procedure event_based;
 
    --%afterall

--- a/test/plsql/test_004_proc_vars.pkb
+++ b/test/plsql/test_004_proc_vars.pkb
@@ -1,0 +1,840 @@
+create or replace package body test_004_proc_vars is
+/* 
+-- Flows for APEX - test_004_proc_varss.pkb
+-- 
+-- (c) Copyright Oracle Corporation and / or its affiliates, 2022.
+--
+-- Created 08-Aug-2022   Richard Allen - Oracle
+--
+*/
+
+  -- uses models 004
+  g_model_a04a constant varchar2(100) := 'A04a - Basic Model';
+
+  g_test_prcs_name constant varchar2(100) := 'test004 - Process Variables';
+
+  g_prcs_id_1       flow_processes.prcs_id%type;
+  g_prcs_id_2       flow_processes.prcs_id%type;
+  g_prcs_id_3       flow_processes.prcs_id%type;
+  g_prcs_id_4       flow_processes.prcs_id%type;
+  g_prcs_id_5       flow_processes.prcs_id%type;
+  g_prcs_dgrm_id  flow_diagrams.dgrm_id%type; -- process level diagram id
+  g_dgrm_a04a_id  flow_diagrams.dgrm_id%type;
+
+  --beforeall
+  procedure set_up_tests
+  is
+        l_actual   sys_refcursor;
+        l_expected sys_refcursor;
+  begin
+
+    -- get dgrm_ids to use for comparison
+    g_dgrm_a04a_id := test_helper.set_dgrm_id( pi_dgrm_name => g_model_a04a );
+    g_prcs_dgrm_id := g_dgrm_a04a_id;
+
+    -- all running and ready for tests 
+
+  end set_up_tests;
+
+
+   procedure basic_flow_variables
+   is
+      l_prcs_id  flow_processes.prcs_id%type;
+      l_dgrm_id  flow_diagrams.dgrm_id%type;
+      l_actual   sys_refcursor;
+      l_expected sys_refcursor;
+      l_vc2_var_name varchar2(10) := 'vc2_var';
+      l_num_var_name varchar2(10) := 'num_var';
+      l_date_var_name varchar2(10) := 'date_var';
+      l_clob_var_name varchar2(10) := 'clob_var';
+      l_expected_vc2 varchar2(4000) := 'TEST';
+      l_expected_num number := 1000;
+      l_expected_date date := to_date('01/01/2022', 'DD/MM/YYYY');
+      l_expected_clob clob := to_clob('TEST');
+      l_actual_vc2 varchar2(4000);
+      l_actual_num number;
+      l_actual_date date;
+      l_actual_clob clob;
+   
+      l_rec flow_process_variables%rowtype;
+   begin
+    -- create a new instance
+    g_prcs_id_1 := flow_api_pkg.flow_create(
+       pi_dgrm_id   => g_prcs_dgrm_id
+     , pi_prcs_name => g_test_prcs_name
+    );
+    l_dgrm_id := g_dgrm_a04a_id;
+    l_prcs_id := g_prcs_id_1;
+    -- check no existing process variables
+    
+    open l_actual for
+    select *
+    from flow_process_variables
+    where prov_prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_have_count( 0 );
+    
+    -- start process and check running status
+    
+    flow_api_pkg.flow_start( p_process_id => l_prcs_id );
+
+    open l_expected for
+        select
+        g_prcs_dgrm_id                              as prcs_dgrm_id,
+        g_test_prcs_name                            as prcs_name,
+        flow_constants_pkg.gc_prcs_status_running   as prcs_status
+        from dual;
+    open l_actual for
+        select prcs_dgrm_id, prcs_name, prcs_status 
+          from flow_processes p
+         where p.prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_equal( l_expected );  
+     
+    -- check subflow running
+   
+      open l_expected for
+         select
+            l_prcs_id           as sbfl_prcs_id,
+            l_dgrm_id           as sbfl_dgrm_id,
+            'A'                 as sbfl_current,
+            flow_constants_pkg.gc_sbfl_status_running as sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_id
+         and sbfl_status not like 'split';
+
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- all running and ready for tests 
+
+      open l_expected for
+          select l_dgrm_id as prcs_dgrm_id
+               , g_test_prcs_name as prcs_name
+               , flow_constants_pkg.gc_prcs_status_running as prcs_status 
+            from dual;
+
+      open l_actual for
+         select prcs_dgrm_id, prcs_name, prcs_status from flow_processes where prcs_id = l_prcs_id;
+
+      ut.expect( l_actual ).to_equal( l_expected );  
+
+      -- Set variables
+      flow_process_vars.set_var(
+           pi_prcs_id     => l_prcs_id
+         , pi_var_name    => l_vc2_var_name
+         , pi_vc2_value   => l_expected_vc2
+      );
+
+      open l_expected for
+         select 
+            l_vc2_var_name  as prov_var_name, 
+            'VARCHAR2'      as prov_var_type, 
+            l_expected_vc2  as prov_var_vc2
+         from dual;
+
+      open l_actual for 
+        select prov_var_name, prov_var_type, prov_var_vc2
+          from flow_process_variables
+         where prov_prcs_id = l_prcs_id
+           and prov_var_name = l_vc2_var_name;
+   
+      ut.expect( l_actual ).to_equal( l_expected );
+
+      open l_actual for 
+         select *
+         from flow_process_variables
+         where prov_prcs_id = l_prcs_id
+         and prov_var_name = l_vc2_var_name;
+
+      fetch l_actual into l_rec;
+
+      ut.expect( l_rec.prov_var_num ).to_be_null();
+      ut.expect( l_rec.prov_var_date ).to_be_null();
+      ut.expect( l_rec.prov_var_clob ).to_be_null(); 
+
+      flow_process_vars.set_var(
+           pi_prcs_id => l_prcs_id
+         , pi_var_name => l_num_var_name
+         , pi_num_value => l_expected_num 
+      );
+
+      open l_expected for
+         select 
+            l_num_var_name as prov_var_name, 
+            'NUMBER' as prov_var_type, 
+            l_expected_num as prov_var_num
+         from dual;
+
+      open l_actual for 
+         select prov_var_name, prov_var_type, prov_var_num
+         from flow_process_variables
+         where prov_prcs_id = l_prcs_id
+         and prov_var_name = l_num_var_name;
+   
+      ut.expect( l_actual ).to_equal( l_expected ); 
+
+      open l_actual for 
+         select *
+         from flow_process_variables
+         where prov_prcs_id = l_prcs_id
+         and prov_var_name = l_num_var_name;
+      fetch l_actual into l_rec;
+
+      ut.expect( l_rec.prov_var_vc2 ).to_be_null();
+      ut.expect( l_rec.prov_var_date ).to_be_null();
+      ut.expect( l_rec.prov_var_clob ).to_be_null(); 
+
+      flow_process_vars.set_var(
+           pi_prcs_id => l_prcs_id
+         , pi_var_name => l_date_var_name
+         , pi_date_value => l_expected_date 
+      );
+
+      open l_expected for
+         select 
+            l_date_var_name as prov_var_name, 
+            'DATE' as prov_var_type, 
+            l_expected_date as prov_var_date
+         from dual;
+
+      open l_actual for 
+         select prov_var_name, prov_var_type, prov_var_date 
+         from flow_process_variables
+         where prov_prcs_id = l_prcs_id
+         and prov_var_name = l_date_var_name;
+   
+      ut.expect( l_actual ).to_equal( l_expected ); 
+
+      open l_actual for 
+         select *
+         from flow_process_variables
+         where prov_prcs_id = l_prcs_id
+         and prov_var_name = l_date_var_name;
+      fetch l_actual into l_rec;
+
+      ut.expect( l_rec.prov_var_vc2 ).to_be_null();
+      ut.expect( l_rec.prov_var_num ).to_be_null();
+      ut.expect( l_rec.prov_var_clob ).to_be_null(); 
+
+      flow_process_vars.set_var(
+           pi_prcs_id => l_prcs_id
+         , pi_var_name => l_clob_var_name
+         , pi_clob_value => l_expected_clob 
+      );
+
+      open l_expected for
+         select 
+            l_clob_var_name as prov_var_name, 
+            'CLOB' as prov_var_type, 
+            l_expected_clob as prov_var_clob
+         from dual;
+
+      open l_actual for 
+         select prov_var_name, prov_var_type, prov_var_clob 
+         from flow_process_variables
+         where prov_prcs_id = l_prcs_id
+         and prov_var_name = l_clob_var_name;
+   
+      ut.expect( l_actual ).to_equal( l_expected ); 
+
+      open l_actual for 
+         select *
+         from flow_process_variables
+         where prov_prcs_id = l_prcs_id
+         and prov_var_name = l_clob_var_name;
+      fetch l_actual into l_rec;
+
+      ut.expect( l_rec.prov_var_vc2 ).to_be_null();
+      ut.expect( l_rec.prov_var_num ).to_be_null();
+      ut.expect( l_rec.prov_var_date ).to_be_null(); 
+
+      -- Get variables
+      l_actual_vc2 := flow_process_vars.get_var_vc2(
+           pi_prcs_id => l_prcs_id
+         , pi_var_name => l_vc2_var_name
+      );
+
+      ut.expect( l_actual_vc2 ).to_equal( l_expected_vc2 );
+
+      l_actual_num := flow_process_vars.get_var_num(
+           pi_prcs_id => l_prcs_id
+         , pi_var_name => l_num_var_name
+      );
+
+      ut.expect( l_actual_num ).to_equal( l_expected_num );
+
+      l_actual_date := flow_process_vars.get_var_date(
+           pi_prcs_id => l_prcs_id
+         , pi_var_name => l_date_var_name
+      );
+
+      ut.expect( l_actual_date ).to_equal( l_expected_date );
+
+      l_actual_clob := flow_process_vars.get_var_clob(
+           pi_prcs_id => l_prcs_id
+         , pi_var_name => l_clob_var_name
+      );
+
+      ut.expect( l_actual_clob ).to_equal( l_expected_clob );
+
+   end basic_flow_variables;
+
+   procedure var_case_sensitivity_vc2
+   is
+      l_prcs_id  flow_processes.prcs_id%type;
+      l_dgrm_id  flow_diagrams.dgrm_id%type;
+      l_actual   sys_refcursor;
+      l_expected sys_refcursor;
+      l_vc2_var_name_lc varchar2(10) := 'vc2_var';
+      l_vc2_var_name_uc varchar2(10) := 'VC2_VAR';
+      l_vc2_var_name_mc varchar2(10) := 'Vc2_vaR';
+      l_vc2_lc_val      varchar2(10) := 'lc';
+      l_vc2_uc_val      varchar2(10) := 'mC';
+      l_vc2_mc_val      varchar2(10) := 'UC';
+      l_actual_vc2 varchar2(4000);
+      l_actual_num number;
+      l_actual_date date;
+      l_actual_clob clob;
+   
+      l_rec flow_process_variables%rowtype;
+   begin
+    -- create a new instance
+    g_prcs_id_2 := flow_api_pkg.flow_create(
+       pi_dgrm_id   => g_prcs_dgrm_id
+     , pi_prcs_name => g_test_prcs_name
+    );
+    l_dgrm_id := g_dgrm_a04a_id;
+    l_prcs_id := g_prcs_id_2;
+    -- check no existing process variables
+    
+    open l_actual for
+    select *
+    from flow_process_variables
+    where prov_prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_have_count( 0 );
+    
+    -- start process and check running status
+    
+    flow_api_pkg.flow_start( p_process_id => l_prcs_id );
+
+    open l_expected for
+        select
+        g_prcs_dgrm_id                              as prcs_dgrm_id,
+        g_test_prcs_name                            as prcs_name,
+        flow_constants_pkg.gc_prcs_status_running   as prcs_status
+        from dual;
+    open l_actual for
+        select prcs_dgrm_id, prcs_name, prcs_status 
+          from flow_processes p
+         where p.prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_equal( l_expected );  
+     
+    -- check subflow running
+   
+      open l_expected for
+         select
+            l_prcs_id           as sbfl_prcs_id,
+            l_dgrm_id           as sbfl_dgrm_id,
+            'A'                 as sbfl_current,
+            flow_constants_pkg.gc_sbfl_status_running as sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_id
+         and sbfl_status not like 'split';
+
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      open l_expected for
+          select l_dgrm_id as prcs_dgrm_id
+               , g_test_prcs_name as prcs_name
+               , flow_constants_pkg.gc_prcs_status_running as prcs_status 
+            from dual;
+
+      open l_actual for
+         select prcs_dgrm_id, prcs_name, prcs_status from flow_processes where prcs_id = l_prcs_id;
+
+      ut.expect( l_actual ).to_equal( l_expected );  
+
+      -- check no existing process variables
+
+      open l_actual for
+      select *
+      from flow_process_variables
+      where prov_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_have_count( 0 );
+
+      -- ready to start test
+
+      -- Set variable originally to lower case value
+      flow_process_vars.set_var(
+           pi_prcs_id     => l_prcs_id
+         , pi_var_name    => l_vc2_var_name_lc
+         , pi_vc2_value   => l_vc2_lc_val
+      );
+
+      -- check now exactly 1 process variable
+
+      open l_actual for
+      select *
+      from flow_process_variables
+      where prov_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_have_count( 1 );
+
+      open l_expected for
+         select 
+            l_vc2_var_name_lc  as prov_var_name, 
+            'VARCHAR2'         as prov_var_type, 
+            l_vc2_lc_val       as prov_var_vc2
+         from dual;
+
+      open l_actual for 
+        select prov_var_name, prov_var_type, prov_var_vc2
+          from flow_process_variables
+         where prov_prcs_id = l_prcs_id;
+   
+      ut.expect( l_actual ).to_equal( l_expected );
+
+      -- existing var from test 1 is 'vc2_var'
+      -- now attempt to set with mixed case - should reset the original var with new content, not create a new var
+      flow_process_vars.set_var(
+           pi_prcs_id     => l_prcs_id
+         , pi_var_name    => l_vc2_var_name_mc
+         , pi_vc2_value   => l_vc2_mc_val
+      );
+
+      -- check now still exactly 1 process variable
+
+      open l_actual for
+      select *
+      from flow_process_variables
+      where prov_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_have_count( 1 );
+
+      open l_expected for
+         select 
+            l_vc2_var_name_lc  as prov_var_name,  -- should keep original name
+            'VARCHAR2'         as prov_var_type, 
+            l_vc2_mc_val       as prov_var_vc2    -- but reset the value
+         from dual;
+
+      open l_actual for 
+        select prov_var_name, prov_var_type, prov_var_vc2
+          from flow_process_variables
+         where prov_prcs_id = l_prcs_id;
+   
+      ut.expect( l_actual ).to_equal( l_expected );
+
+      -- now attempt to set with upper case - should reset the original var with new content, not create a new var
+      flow_process_vars.set_var(
+           pi_prcs_id     => l_prcs_id
+         , pi_var_name    => l_vc2_var_name_uc
+         , pi_vc2_value   => l_vc2_uc_val
+      );
+
+      -- check now still exactly 1 process variable
+
+      open l_actual for
+      select *
+      from flow_process_variables
+      where prov_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_have_count( 1 );
+
+      open l_expected for
+         select 
+            l_vc2_var_name_lc  as prov_var_name,  -- should keep original name
+            'VARCHAR2'         as prov_var_type, 
+            l_vc2_uc_val       as prov_var_vc2    -- but reset the value
+         from dual;
+
+      open l_actual for 
+        select prov_var_name, prov_var_type, prov_var_vc2
+          from flow_process_variables
+         where prov_prcs_id = l_prcs_id;
+   
+      ut.expect( l_actual ).to_equal( l_expected );
+
+   end var_case_sensitivity_vc2;
+
+   procedure var_case_sensitivity_num
+   is
+      l_prcs_id  flow_processes.prcs_id%type;
+      l_dgrm_id  flow_diagrams.dgrm_id%type;
+      l_actual   sys_refcursor;
+      l_expected sys_refcursor;
+      l_num_var_name_lc varchar2(10) := 'vc2_var';
+      l_num_var_name_uc varchar2(10) := 'VC2_VAR';
+      l_num_var_name_mc varchar2(10) := 'Vc2_vaR';
+      l_num_lc_val      number := 10;
+      l_num_uc_val      number := 20;
+      l_num_mc_val      number := 30;
+      l_actual_vc2 varchar2(4000);
+      l_actual_num number;
+      l_actual_date date;
+      l_actual_clob clob;
+   
+      l_rec flow_process_variables%rowtype;
+   begin
+    -- create a new instance
+    g_prcs_id_3 := flow_api_pkg.flow_create(
+       pi_dgrm_id   => g_prcs_dgrm_id
+     , pi_prcs_name => g_test_prcs_name
+    );
+    l_dgrm_id := g_dgrm_a04a_id;
+    l_prcs_id := g_prcs_id_3;
+    -- check no existing process variables
+    
+    open l_actual for
+    select *
+    from flow_process_variables
+    where prov_prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_have_count( 0 );
+    
+    -- start process and check running status
+    
+    flow_api_pkg.flow_start( p_process_id => l_prcs_id );
+
+    open l_expected for
+        select
+        g_prcs_dgrm_id                              as prcs_dgrm_id,
+        g_test_prcs_name                            as prcs_name,
+        flow_constants_pkg.gc_prcs_status_running   as prcs_status
+        from dual;
+    open l_actual for
+        select prcs_dgrm_id, prcs_name, prcs_status 
+          from flow_processes p
+         where p.prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_equal( l_expected );  
+     
+    -- check subflow running
+   
+      open l_expected for
+         select
+            l_prcs_id           as sbfl_prcs_id,
+            l_dgrm_id           as sbfl_dgrm_id,
+            'A'                 as sbfl_current,
+            flow_constants_pkg.gc_sbfl_status_running as sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_id
+         and sbfl_status not like 'split';
+
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      open l_expected for
+          select l_dgrm_id as prcs_dgrm_id
+               , g_test_prcs_name as prcs_name
+               , flow_constants_pkg.gc_prcs_status_running as prcs_status 
+            from dual;
+
+      open l_actual for
+         select prcs_dgrm_id, prcs_name, prcs_status from flow_processes where prcs_id = l_prcs_id;
+
+      ut.expect( l_actual ).to_equal( l_expected );  
+
+      -- check no existing process variables
+
+      open l_actual for
+      select *
+      from flow_process_variables
+      where prov_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_have_count( 0 );
+
+      -- ready to start test
+
+      -- Set variable originally to lower case value
+      flow_process_vars.set_var(
+           pi_prcs_id     => l_prcs_id
+         , pi_var_name    => l_num_var_name_lc
+         , pi_num_value   => l_num_lc_val
+      );
+
+      -- check now exactly 1 process variable
+
+      open l_actual for
+      select *
+      from flow_process_variables
+      where prov_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_have_count( 1 );
+
+      open l_expected for
+         select 
+            l_num_var_name_lc  as prov_var_name, 
+            'NUMBER'         as prov_var_type, 
+            l_num_lc_val       as prov_var_num
+         from dual;
+
+      open l_actual for 
+        select prov_var_name, prov_var_type, prov_var_num
+          from flow_process_variables
+         where prov_prcs_id = l_prcs_id;
+   
+      ut.expect( l_actual ).to_equal( l_expected );
+
+      -- existing var from test 1 is 'vc2_var'
+      -- now attempt to set with mixed case - should reset the original var with new content, not create a new var
+      flow_process_vars.set_var(
+           pi_prcs_id     => l_prcs_id
+         , pi_var_name    => l_num_var_name_mc
+         , pi_num_value   => l_num_mc_val
+      );
+
+      -- check now still exactly 1 process variable
+
+      open l_actual for
+      select *
+      from flow_process_variables
+      where prov_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_have_count( 1 );
+
+      open l_expected for
+         select 
+            l_num_var_name_lc  as prov_var_name,  -- should keep original name
+            'NUMBER'         as prov_var_type, 
+            l_num_mc_val       as prov_var_num    -- but reset the value
+         from dual;
+
+      open l_actual for 
+        select prov_var_name, prov_var_type, prov_var_num
+          from flow_process_variables
+         where prov_prcs_id = l_prcs_id;
+   
+      ut.expect( l_actual ).to_equal( l_expected );
+
+      -- now attempt to set with upper case - should reset the original var with new content, not create a new var
+      flow_process_vars.set_var(
+           pi_prcs_id     => l_prcs_id
+         , pi_var_name    => l_num_var_name_uc
+         , pi_num_value   => l_num_uc_val
+      );
+
+      -- check now still exactly 1 process variable
+
+      open l_actual for
+      select *
+      from flow_process_variables
+      where prov_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_have_count( 1 );
+
+      open l_expected for
+         select 
+            l_num_var_name_lc  as prov_var_name,  -- should keep original name
+            'NUMBER'           as prov_var_type, 
+            l_num_uc_val       as prov_var_num    -- but reset the value
+         from dual;
+
+      open l_actual for 
+        select prov_var_name, prov_var_type, prov_var_num
+          from flow_process_variables
+         where prov_prcs_id = l_prcs_id;
+   
+      ut.expect( l_actual ).to_equal( l_expected );
+
+   end var_case_sensitivity_num;
+
+
+   procedure var_case_sensitivity_date
+   is
+      l_prcs_id  flow_processes.prcs_id%type;
+      l_dgrm_id  flow_diagrams.dgrm_id%type;
+      l_actual   sys_refcursor;
+      l_expected sys_refcursor;
+      l_date_var_name_lc varchar2(10) := 'date_var';
+      l_date_var_name_uc varchar2(10) := 'DATE_VAR';
+      l_date_var_name_mc varchar2(10) := 'dAtE_vaR';
+      l_date_lc_val      varchar2(20) := '01-JAN-2022';
+      l_date_uc_val      varchar2(20) := '11-FEB-2022';
+      l_date_mc_val      varchar2(20) := '22-MAR-2022';
+      l_actual_vc2 varchar2(4000);
+      l_actual_num number;
+      l_actual_date date;
+      l_actual_clob clob;
+   
+      l_rec flow_process_variables%rowtype;
+   begin
+    -- create a new instance
+    g_prcs_id_4 := flow_api_pkg.flow_create(
+       pi_dgrm_id   => g_prcs_dgrm_id
+     , pi_prcs_name => g_test_prcs_name
+    );
+    l_dgrm_id := g_dgrm_a04a_id;
+    l_prcs_id := g_prcs_id_4;
+    -- check no existing process variables
+    
+    open l_actual for
+    select *
+    from flow_process_variables
+    where prov_prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_have_count( 0 );
+    
+    -- start process and check running status
+    
+    flow_api_pkg.flow_start( p_process_id => l_prcs_id );
+
+    open l_expected for
+        select
+        g_prcs_dgrm_id                              as prcs_dgrm_id,
+        g_test_prcs_name                            as prcs_name,
+        flow_constants_pkg.gc_prcs_status_running   as prcs_status
+        from dual;
+    open l_actual for
+        select prcs_dgrm_id, prcs_name, prcs_status 
+          from flow_processes p
+         where p.prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_equal( l_expected );  
+     
+    -- check subflow running
+   
+      open l_expected for
+         select
+            l_prcs_id           as sbfl_prcs_id,
+            l_dgrm_id           as sbfl_dgrm_id,
+            'A'                 as sbfl_current,
+            flow_constants_pkg.gc_sbfl_status_running as sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_id
+         and sbfl_status not like 'split';
+
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      open l_expected for
+          select l_dgrm_id as prcs_dgrm_id
+               , g_test_prcs_name as prcs_name
+               , flow_constants_pkg.gc_prcs_status_running as prcs_status 
+            from dual;
+
+      open l_actual for
+         select prcs_dgrm_id, prcs_name, prcs_status from flow_processes where prcs_id = l_prcs_id;
+
+      ut.expect( l_actual ).to_equal( l_expected );  
+
+      -- check no existing process variables
+
+      open l_actual for
+      select *
+      from flow_process_variables
+      where prov_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_have_count( 0 );
+
+      -- ready to start test
+
+      -- Set variable originally to lower case value
+      flow_process_vars.set_var(
+           pi_prcs_id     => l_prcs_id
+         , pi_var_name    => l_date_var_name_lc
+         , pi_date_value   => to_date(l_date_lc_val,'DD-MON-YYYY')
+      );
+
+      -- check now exactly 1 process variable
+
+      open l_actual for
+      select *
+      from flow_process_variables
+      where prov_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_have_count( 1 );
+
+      open l_expected for
+         select 
+            l_date_var_name_lc                        as prov_var_name, 
+            'DATE'                                    as prov_var_type, 
+            to_date(l_date_lc_val,'DD-MON-YYYY')      as prov_var_date
+         from dual;
+
+      open l_actual for 
+        select prov_var_name, prov_var_type, prov_var_date
+          from flow_process_variables
+         where prov_prcs_id = l_prcs_id;
+   
+      ut.expect( l_actual ).to_equal( l_expected );
+
+      -- existing var from test 1 is 'vc2_var'
+      -- now attempt to set with mixed case - should reset the original var with new content, not create a new var
+      flow_process_vars.set_var(
+           pi_prcs_id     => l_prcs_id
+         , pi_var_name    => l_date_var_name_mc
+         , pi_date_value  => l_date_mc_val
+      );
+
+      -- check now still exactly 1 process variable
+
+      open l_actual for
+      select *
+      from flow_process_variables
+      where prov_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_have_count( 1 );
+
+      open l_expected for
+         select 
+            l_date_var_name_lc                            as prov_var_name,  -- should keep original name
+            'DATE'                                        as prov_var_type, 
+            to_date( l_date_mc_val ,'DD-MON-YYYY')        as prov_var_date     -- but reset the value
+         from dual;
+
+      open l_actual for 
+        select prov_var_name, prov_var_type, prov_var_date
+          from flow_process_variables
+         where prov_prcs_id = l_prcs_id;
+   
+      ut.expect( l_actual ).to_equal( l_expected );
+
+      -- now attempt to set with upper case - should reset the original var with new content, not create a new var
+      flow_process_vars.set_var(
+           pi_prcs_id     => l_prcs_id
+         , pi_var_name    => l_date_var_name_uc
+         , pi_date_value  => l_date_uc_val
+      );
+
+      -- check now still exactly 1 process variable
+
+      open l_actual for
+      select *
+      from flow_process_variables
+      where prov_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_have_count( 1 );
+
+      open l_expected for
+         select 
+            l_date_var_name_lc                          as prov_var_name,  -- should keep original name
+            'DATE'                                      as prov_var_type, 
+            to_date(l_date_uc_val ,'DD-MON-YYYY')       as prov_var_date    -- but reset the value
+         from dual;
+
+      open l_actual for 
+        select prov_var_name, prov_var_type, prov_var_date
+          from flow_process_variables
+         where prov_prcs_id = l_prcs_id;
+   
+      ut.expect( l_actual ).to_equal( l_expected );
+
+   end var_case_sensitivity_date;
+
+  -- afterall
+  procedure tear_down_tests 
+  is
+  begin
+    flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_1,
+                             p_comment  => 'Ran by utPLSQL as Test Suite 004');
+    flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_2,
+                             p_comment  => 'Ran by utPLSQL as Test Suite 004');
+    flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_3,
+                             p_comment  => 'Ran by utPLSQL as Test Suite 004');
+    flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_4,
+                             p_comment  => 'Ran by utPLSQL as Test Suite 004');
+    flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_5,
+                             p_comment  => 'Ran by utPLSQL as Test Suite 004');
+    ut.expect( v('APP_SESSION')).to_be_null;
+           
+  end tear_down_tests;
+
+end test_004_proc_vars;

--- a/test/plsql/test_004_proc_vars.pks
+++ b/test/plsql/test_004_proc_vars.pks
@@ -1,0 +1,34 @@
+create or replace package test_004_proc_vars is
+
+   -- uses model A01
+
+   -- tests  process variable functions
+
+   --%suite(Process Variable operations)
+   --%rollback(manual)
+
+   -- Need to add tests for by name, by name and version, by id
+   -- Maybe need to test the versionning logic as well here?
+
+  --%beforeall
+  procedure set_up_tests;
+
+
+  --%test(1. Basic Process Variable Operations - duplicates test in suite 001)
+  procedure basic_flow_variables;
+
+  --%test(2. Case sensitivity of Proc Vars - vc2)
+  procedure var_case_sensitivity_vc2;
+
+  --%test(2. Case sensitivity of Proc Vars - date)
+  procedure var_case_sensitivity_num;
+
+    --%test(2. Case sensitivity of Proc Vars - number)
+  procedure var_case_sensitivity_date;
+
+
+
+  --%afterall
+  procedure tear_down_tests;
+
+end test_004_proc_vars;


### PR DESCRIPTION
We had the situation where process variables were (in some places) case sensitive, and other places case insensitive.  This change:
- makes process variables case independent.  'MyVar', 'MYVAR', and 'myvar' are now all the same variable.
- flow_process_variables table now had a unique index on prcs_id, scope, upper(var_name)
- references to var_name in queries, updates, deletes now look for upper(var_name)
- cases where process variables are accessed specially (timers, gateway routing, approvals) have been handled
- added a new test suite 004 to test this and as a basis for further testing of process variables
- enhanced the gateway test suite 002 to explicitly test gateway routing variables of mixed, upper, lower, etc., case
- migration script not complete, but functional requirements added to script.