### PR TITLE
Process Variables for Binds

### DIFF
--- a/src/ddl/install_scratch.sql
+++ b/src/ddl/install_scratch.sql
@@ -330,7 +330,7 @@ create table flow_process_variables
 , prov_var_num number
 , prov_var_date date
 , prov_var_clob clob
-, prov_var_name_uc varchar2(50 char) generated always as upper(prov_var_name)
+, prov_var_name_uc varchar2(50 char) generated always as ( upper(prov_var_name) )
 );
 
 alter table flow_process_variables add constraint prov_pk primary key (prov_prcs_id, prov_scope, prov_var_name_uc);

--- a/src/migrations/22.1_to_22.2/issue-77.sql
+++ b/src/migrations/22.1_to_22.2/issue-77.sql
@@ -3,6 +3,6 @@ PROMPT >> Migration for Case-insensitive process variables (issue77)
 -- 1. BEFORE MIGRATION STARTS, NEED TO CHECK (prov_prcs_id, prov_scope, upper (prov_var_name)) IS UNIQUE
 -- 2. NEEDS TO RUN AFTER feature-172.sql (which creates prov_scope column)
 
-alter table flow_process_variables add (prov_var_name_uc varchar2(50 char) generated always as upper(prov_var_name));
+alter table flow_process_variables add (prov_var_name_uc varchar2(50 char) generated always as (upper(prov_var_name)));
 alter table flow_process_variables drop primary key;
 alter table flow_process_variables add constraint prov_pk primary key (prov_prcs_id, prov_scope, prov_var_name_uc);

--- a/src/plsql/flow_gateways.pkb
+++ b/src/plsql/flow_gateways.pkb
@@ -138,6 +138,7 @@ as
       -- loop over routes
       for route in 1 .. l_possible_routes.count
       loop
+        l_bind_list := apex_plugin_util.c_empty_bind_list;
         apex_debug.info( p_message => '-- Evaluating Route #%0, Language: %1, Expression: %2', p0 => route, p1 => l_possible_routes(route).conn_language, p2 => l_possible_routes(route).conn_expression );
         l_take_route := false;
         -- evaluate route expression
@@ -188,8 +189,7 @@ as
             l_indx := l_var_list.next (l_indx);
           end loop;
         else
-          -- no bind variables
-          l_bind_list := apex_plugin_util.c_empty_bind_list;                      
+          -- no bind variables, nothing to do as we reset bind-list for each loop
           apex_debug.info (p_message => 'Expression contains no bind variables.  Expression : %0 type : %1  '
             , p0 => l_expr
             , p1 => l_expr_type); 

--- a/src/plsql/flow_gateways.pkb
+++ b/src/plsql/flow_gateways.pkb
@@ -175,7 +175,7 @@ as
           while l_indx is not null 
           loop
             l_bind.name  := flow_constants_pkg.gc_substitution_flow_identifier || l_var_list(l_indx);
-            l_bind.value := flow_proc_vars_int.get_var_vc2
+            l_bind.value := flow_proc_vars_int.get_var_as_vc2
                               ( pi_prcs_id            => pi_prcs_id
                               , pi_var_name           => l_var_list(l_indx)
                               , pi_scope              => pi_scope

--- a/src/plsql/flow_proc_vars_int.pks
+++ b/src/plsql/flow_proc_vars_int.pks
@@ -1,15 +1,16 @@
+create or replace package flow_proc_vars_int
+  authid definer
+as 
 /* 
 -- Flows for APEX - flow_proc_vars_int.pks
 -- 
 -- (c) Copyright Oracle Corporation and / or its affiliates, 2022.
 --
 -- Created    12-Apr-2022  Richard Allen (Oracle)
+-- Modified   11-Aug-2022  Moritz Klein (MT AG)
 --
 */
 
-create or replace package flow_proc_vars_int
-  authid definer
-as 
  /********************************************************************************
 **
 **        PROCESS VARIABLE SYSTEM (get / set / etc) 
@@ -155,6 +156,22 @@ function scope_is_valid
 ( pi_prcs_id in flow_processes.prcs_id%type
 , pi_scope   in flow_subflows.sbfl_scope%type
 ) return boolean;
+
+  procedure get_var_as_parameter
+  (
+    pi_prcs_id    in flow_process_variables.prov_prcs_id%type
+  , pi_var_name   in flow_process_variables.prov_var_name%type
+  , pi_scope      in flow_process_variables.prov_scope%type
+  , po_data_type out apex_exec.t_data_type
+  , po_value     out apex_exec.t_value
+  );
+
+  function get_var_as_vc2
+  (
+    pi_prcs_id    in flow_process_variables.prov_prcs_id%type
+  , pi_var_name   in flow_process_variables.prov_var_name%type
+  , pi_scope      in flow_process_variables.prov_scope%type
+  ) return varchar2;
 
 end flow_proc_vars_int;
 /


### PR DESCRIPTION
* New internal function get vc2, number or date process variable as vc2
* fixed missing () for virtual columns (12.2 only)
* flow_gateways can now bind vc2, number and date process variables