### PR TITLE
Issues/issue 510 Fix Inclusive Merge then ReSplit Gateways

### DIFF
--- a/src/plsql/flow_gateways.pkb
+++ b/src/plsql/flow_gateways.pkb
@@ -684,7 +684,7 @@ as
         ( pi_objt_id     => p_step_info.target_objt_id
         , pi_set         => flow_constants_pkg.gc_expr_set_before_split
         , pi_prcs_id     => p_sbfl_info.sbfl_prcs_id
-        , pi_sbfl_id     => p_sbfl_info.sbfl_id
+        , pi_sbfl_id     => l_sbfl_id
         , pi_var_scope   => p_sbfl_info.sbfl_scope
         , pi_expr_scope  => p_sbfl_info.sbfl_scope
         );        
@@ -696,7 +696,7 @@ as
           when flow_constants_pkg.gc_bpmn_gateway_inclusive then 
             l_forward_routes := get_gateway_route
             ( pi_prcs_id       => p_sbfl_info.sbfl_prcs_id
-            , pi_sbfl_id       => p_sbfl_info.sbfl_id --l_sbfl_id?
+            , pi_sbfl_id       => l_sbfl_id --l_sbfl_id?
             , pi_objt_bpmn_id   => p_step_info.target_objt_ref
             , pi_objt_tag       => p_step_info.target_objt_tag
             , pi_scope          => p_sbfl_info.sbfl_scope
@@ -729,14 +729,14 @@ as
             -- has step errors from evaluating route
             flow_errors.set_error_status
             ( pi_prcs_id => p_sbfl_info.sbfl_prcs_id
-            , pi_sbfl_id => p_sbfl_info.sbfl_id
+            , pi_sbfl_id => l_sbfl_id
             );
           end if;
         else
           -- has step errors from expressions
           flow_errors.set_error_status
           ( pi_prcs_id => p_sbfl_info.sbfl_prcs_id
-          , pi_sbfl_id => p_sbfl_info.sbfl_id
+          , pi_sbfl_id => l_sbfl_id
           );
         end if;
       elsif l_num_forward_connections = 1 then

--- a/src/plsql/flow_gateways.pkb
+++ b/src/plsql/flow_gateways.pkb
@@ -61,11 +61,12 @@ as
 
       if l_bad_routes.count > 0 then
         -- we have some invalid routes in the routing variable
-        for l_row in 1 .. l_bad_routes.count
-        loop
-          l_bad_route_string := l_bad_route_string || l_bad_routes(l_row) ||',';
-        end loop;
-        l_bad_route_string := rtrim (l_bad_route_string, ',');
+        l_bad_route_string := apex_string.join(l_bad_routes,',');
+        apex_debug.message ( 
+          p_message => 'Invalid routes found - count %0, bad routes: %1)'
+        , p0 => l_bad_routes.count
+        , p1 => l_bad_route_string 
+        );
         raise flow_errors.e_gateway_invalid_route;
       end if;
     exception
@@ -695,7 +696,7 @@ as
           when flow_constants_pkg.gc_bpmn_gateway_inclusive then 
             l_forward_routes := get_gateway_route
             ( pi_prcs_id       => p_sbfl_info.sbfl_prcs_id
-            , pi_sbfl_id       => p_sbfl_info.sbfl_id
+            , pi_sbfl_id       => p_sbfl_info.sbfl_id --l_sbfl_id?
             , pi_objt_bpmn_id   => p_step_info.target_objt_ref
             , pi_objt_tag       => p_step_info.target_objt_tag
             , pi_scope          => p_sbfl_info.sbfl_scope

--- a/test/models/A02i - Inc GW Merge and Resplit_0.bpmn
+++ b/test/models/A02i - Inc GW Merge and Resplit_0.bpmn
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:apex="https://flowsforapex.org" id="Definitions_1wzb475" targetNamespace="http://bpmn.io/schema/b" exporter="Flows for APEX" exporterVersion="22.2.0">
+  <bpmn:process id="Process_12i" name="Test Model 12i - Merge Split Inc Gateways" isExecutable="false" apex:isCallable="false" apex:manualInput="false">
+    <bpmn:startEvent id="Event_Start" name="Start">
+      <bpmn:outgoing>Flow_194r471</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_194r471" sourceRef="Event_Start" targetRef="Activity_Pre" />
+    <bpmn:inclusiveGateway id="Gateway_Split" name="Gateway Split">
+      <bpmn:incoming>Flow_0wbb8yo</bpmn:incoming>
+      <bpmn:outgoing>Flow_X</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Y</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:task id="Activity_X" name="X">
+      <bpmn:incoming>Flow_X</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xmwnsp</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_X" name="Flow_X" sourceRef="Gateway_Split" targetRef="Activity_X" apex:sequence="20" />
+    <bpmn:sequenceFlow id="Flow_0xmwnsp" sourceRef="Activity_X" targetRef="Gateway_MergeSplit" />
+    <bpmn:inclusiveGateway id="Gateway_MergeSplit" name="Gateway MergeSplit">
+      <bpmn:incoming>Flow_0xmwnsp</bpmn:incoming>
+      <bpmn:incoming>Flow_01prxwy</bpmn:incoming>
+      <bpmn:outgoing>Flow_B</bpmn:outgoing>
+      <bpmn:outgoing>Flow_C</bpmn:outgoing>
+      <bpmn:outgoing>Flow_A</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:task id="Activity_Y" name="Y">
+      <bpmn:incoming>Flow_Y</bpmn:incoming>
+      <bpmn:outgoing>Flow_01prxwy</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_Y" name="Flow_Y" sourceRef="Gateway_Split" targetRef="Activity_Y" apex:sequence="30" />
+    <bpmn:sequenceFlow id="Flow_01prxwy" sourceRef="Activity_Y" targetRef="Gateway_MergeSplit" />
+    <bpmn:task id="Activity_B" name="B">
+      <bpmn:incoming>Flow_B</bpmn:incoming>
+      <bpmn:outgoing>Flow_1x0kegj</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_B" name="Flow_B" sourceRef="Gateway_MergeSplit" targetRef="Activity_B" apex:sequence="30" />
+    <bpmn:task id="Activity_C" name="C">
+      <bpmn:incoming>Flow_C</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xhau1w</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_C" name="Flow_C" sourceRef="Gateway_MergeSplit" targetRef="Activity_C" apex:sequence="40" />
+    <bpmn:task id="Activity_A" name="A">
+      <bpmn:incoming>Flow_A</bpmn:incoming>
+      <bpmn:outgoing>Flow_08ltn03</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_A" name="Flow_A" sourceRef="Gateway_MergeSplit" targetRef="Activity_A" apex:sequence="50" />
+    <bpmn:endEvent id="Event_EndA" name="EndA">
+      <bpmn:incoming>Flow_08ltn03</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_08ltn03" sourceRef="Activity_A" targetRef="Event_EndA" />
+    <bpmn:endEvent id="Event_EndB" name="EndB">
+      <bpmn:incoming>Flow_1x0kegj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1x0kegj" sourceRef="Activity_B" targetRef="Event_EndB" />
+    <bpmn:endEvent id="Event_EndC" name="EndC">
+      <bpmn:incoming>Flow_1xhau1w</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1xhau1w" sourceRef="Activity_C" targetRef="Event_EndC" />
+    <bpmn:task id="Activity_Pre" name="Activity_Pre">
+      <bpmn:incoming>Flow_194r471</bpmn:incoming>
+      <bpmn:outgoing>Flow_0wbb8yo</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0wbb8yo" sourceRef="Activity_Pre" targetRef="Gateway_Split" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_12i">
+      <bpmndi:BPMNEdge id="Flow_0wbb8yo_di" bpmnElement="Flow_0wbb8yo">
+        <di:waypoint x="340" y="480" />
+        <di:waypoint x="395" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xhau1w_di" bpmnElement="Flow_1xhau1w">
+        <di:waypoint x="920" y="590" />
+        <di:waypoint x="962" y="590" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="912" y="572" width="28" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1x0kegj_di" bpmnElement="Flow_1x0kegj">
+        <di:waypoint x="920" y="480" />
+        <di:waypoint x="962" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08ltn03_di" bpmnElement="Flow_08ltn03">
+        <di:waypoint x="920" y="360" />
+        <di:waypoint x="962" y="360" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nw9ma2_di" bpmnElement="Flow_A">
+        <di:waypoint x="725" y="480" />
+        <di:waypoint x="750" y="480" />
+        <di:waypoint x="750" y="360" />
+        <di:waypoint x="820" y="360" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="757" y="333" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18utc2b_di" bpmnElement="Flow_C">
+        <di:waypoint x="730" y="480" />
+        <di:waypoint x="750" y="480" />
+        <di:waypoint x="750" y="590" />
+        <di:waypoint x="820" y="590" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="757" y="563" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nowoj9_di" bpmnElement="Flow_B">
+        <di:waypoint x="725" y="480" />
+        <di:waypoint x="820" y="480" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="757" y="462" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01prxwy_di" bpmnElement="Flow_01prxwy">
+        <di:waypoint x="610" y="590" />
+        <di:waypoint x="700" y="590" />
+        <di:waypoint x="700" y="505" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1k4vll4_di" bpmnElement="Flow_Y">
+        <di:waypoint x="420" y="505" />
+        <di:waypoint x="420" y="590" />
+        <di:waypoint x="510" y="590" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="418" y="545" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xmwnsp_di" bpmnElement="Flow_0xmwnsp">
+        <di:waypoint x="610" y="390" />
+        <di:waypoint x="700" y="390" />
+        <di:waypoint x="700" y="455" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1czj7yc_di" bpmnElement="Flow_X">
+        <di:waypoint x="420" y="455" />
+        <di:waypoint x="420" y="390" />
+        <di:waypoint x="510" y="390" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="418" y="420" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_194r471_di" bpmnElement="Flow_194r471">
+        <di:waypoint x="178" y="480" />
+        <di:waypoint x="240" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_083kw68_di" bpmnElement="Event_Start">
+        <dc:Bounds x="142" y="462" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="149" y="505" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0mibtpu_di" bpmnElement="Gateway_Split">
+        <dc:Bounds x="395" y="455" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="337" y="433" width="66" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08fxb0u_di" bpmnElement="Activity_X">
+        <dc:Bounds x="510" y="350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1e99cbp_di" bpmnElement="Gateway_MergeSplit">
+        <dc:Bounds x="675" y="455" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="605" y="466" width="51" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0sexfio_di" bpmnElement="Activity_Y">
+        <dc:Bounds x="510" y="550" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cc3rtq_di" bpmnElement="Activity_B">
+        <dc:Bounds x="820" y="440" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ebr62n_di" bpmnElement="Activity_C">
+        <dc:Bounds x="820" y="550" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mhvq0l_di" bpmnElement="Activity_A">
+        <dc:Bounds x="820" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mdcz4r_di" bpmnElement="Event_EndA">
+        <dc:Bounds x="962" y="342" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="967" y="385" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0sfuiu4_di" bpmnElement="Event_EndB">
+        <dc:Bounds x="962" y="462" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="967" y="505" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ohlzoq_di" bpmnElement="Event_EndC">
+        <dc:Bounds x="962" y="572" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="966" y="615" width="28" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1lhi4zo_di" bpmnElement="Activity_Pre">
+        <dc:Bounds x="240" y="440" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/models/A02j - Par GW Merge and Resplit_0.bpmn
+++ b/test/models/A02j - Par GW Merge and Resplit_0.bpmn
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:apex="https://flowsforapex.org" id="Definitions_1wzb475" targetNamespace="http://bpmn.io/schema/b" exporter="Flows for APEX" exporterVersion="22.2.0">
+  <bpmn:process id="Process_12j" name="Test Model 12j - Merge Split Par Gateways" isExecutable="false" apex:isCallable="false" apex:manualInput="false">
+    <bpmn:startEvent id="Event_Start" name="Start">
+      <bpmn:outgoing>Flow_194r471</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_194r471" sourceRef="Event_Start" targetRef="Activity_Pre" />
+    <bpmn:task id="Activity_X" name="X">
+      <bpmn:incoming>Flow_X</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xmwnsp</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_X" name="Flow_X" sourceRef="Gateway_Split" targetRef="Activity_X" apex:sequence="20" />
+    <bpmn:sequenceFlow id="Flow_0xmwnsp" sourceRef="Activity_X" targetRef="Gateway_MergeSplit" />
+    <bpmn:task id="Activity_Y" name="Y">
+      <bpmn:incoming>Flow_Y</bpmn:incoming>
+      <bpmn:outgoing>Flow_01prxwy</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_Y" name="Flow_Y" sourceRef="Gateway_Split" targetRef="Activity_Y" apex:sequence="30" />
+    <bpmn:sequenceFlow id="Flow_01prxwy" sourceRef="Activity_Y" targetRef="Gateway_MergeSplit" />
+    <bpmn:task id="Activity_B" name="B">
+      <bpmn:incoming>Flow_B</bpmn:incoming>
+      <bpmn:outgoing>Flow_1x0kegj</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_B" name="Flow_B" sourceRef="Gateway_MergeSplit" targetRef="Activity_B" apex:sequence="30" />
+    <bpmn:task id="Activity_C" name="C">
+      <bpmn:incoming>Flow_C</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xhau1w</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_C" name="Flow_C" sourceRef="Gateway_MergeSplit" targetRef="Activity_C" apex:sequence="40" />
+    <bpmn:task id="Activity_A" name="A">
+      <bpmn:incoming>Flow_A</bpmn:incoming>
+      <bpmn:outgoing>Flow_08ltn03</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_A" name="Flow_A" sourceRef="Gateway_MergeSplit" targetRef="Activity_A" apex:sequence="50" />
+    <bpmn:endEvent id="Event_EndA" name="EndA">
+      <bpmn:incoming>Flow_08ltn03</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_08ltn03" sourceRef="Activity_A" targetRef="Event_EndA" />
+    <bpmn:endEvent id="Event_EndB" name="EndB">
+      <bpmn:incoming>Flow_1x0kegj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1x0kegj" sourceRef="Activity_B" targetRef="Event_EndB" />
+    <bpmn:endEvent id="Event_EndC" name="EndC">
+      <bpmn:incoming>Flow_1xhau1w</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1xhau1w" sourceRef="Activity_C" targetRef="Event_EndC" />
+    <bpmn:task id="Activity_Pre" name="Activity_Pre">
+      <bpmn:incoming>Flow_194r471</bpmn:incoming>
+      <bpmn:outgoing>Flow_0wbb8yo</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0wbb8yo" sourceRef="Activity_Pre" targetRef="Gateway_Split" />
+    <bpmn:parallelGateway id="Gateway_Split" name="Gateway Split">
+      <bpmn:incoming>Flow_0wbb8yo</bpmn:incoming>
+      <bpmn:outgoing>Flow_X</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Y</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="Gateway_MergeSplit" name="Gateway MergeSplit">
+      <bpmn:incoming>Flow_0xmwnsp</bpmn:incoming>
+      <bpmn:incoming>Flow_01prxwy</bpmn:incoming>
+      <bpmn:outgoing>Flow_B</bpmn:outgoing>
+      <bpmn:outgoing>Flow_C</bpmn:outgoing>
+      <bpmn:outgoing>Flow_A</bpmn:outgoing>
+    </bpmn:parallelGateway>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_12j">
+      <bpmndi:BPMNEdge id="Flow_0wbb8yo_di" bpmnElement="Flow_0wbb8yo">
+        <di:waypoint x="340" y="480" />
+        <di:waypoint x="395" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xhau1w_di" bpmnElement="Flow_1xhau1w">
+        <di:waypoint x="920" y="590" />
+        <di:waypoint x="962" y="590" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="912" y="572" width="28" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1x0kegj_di" bpmnElement="Flow_1x0kegj">
+        <di:waypoint x="920" y="480" />
+        <di:waypoint x="962" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08ltn03_di" bpmnElement="Flow_08ltn03">
+        <di:waypoint x="920" y="360" />
+        <di:waypoint x="962" y="360" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nw9ma2_di" bpmnElement="Flow_A">
+        <di:waypoint x="725" y="480" />
+        <di:waypoint x="750" y="480" />
+        <di:waypoint x="750" y="360" />
+        <di:waypoint x="820" y="360" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="757" y="333" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18utc2b_di" bpmnElement="Flow_C">
+        <di:waypoint x="725" y="480" />
+        <di:waypoint x="750" y="480" />
+        <di:waypoint x="750" y="590" />
+        <di:waypoint x="820" y="590" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="757" y="563" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nowoj9_di" bpmnElement="Flow_B">
+        <di:waypoint x="725" y="480" />
+        <di:waypoint x="820" y="480" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="757" y="462" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01prxwy_di" bpmnElement="Flow_01prxwy">
+        <di:waypoint x="610" y="590" />
+        <di:waypoint x="700" y="590" />
+        <di:waypoint x="700" y="505" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1k4vll4_di" bpmnElement="Flow_Y">
+        <di:waypoint x="420" y="505" />
+        <di:waypoint x="420" y="590" />
+        <di:waypoint x="510" y="590" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="418" y="545" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xmwnsp_di" bpmnElement="Flow_0xmwnsp">
+        <di:waypoint x="610" y="390" />
+        <di:waypoint x="700" y="390" />
+        <di:waypoint x="700" y="455" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1czj7yc_di" bpmnElement="Flow_X">
+        <di:waypoint x="420" y="455" />
+        <di:waypoint x="420" y="390" />
+        <di:waypoint x="510" y="390" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="418" y="420" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_194r471_di" bpmnElement="Flow_194r471">
+        <di:waypoint x="178" y="480" />
+        <di:waypoint x="240" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_083kw68_di" bpmnElement="Event_Start">
+        <dc:Bounds x="142" y="462" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="149" y="505" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08fxb0u_di" bpmnElement="Activity_X">
+        <dc:Bounds x="510" y="350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0sexfio_di" bpmnElement="Activity_Y">
+        <dc:Bounds x="510" y="550" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cc3rtq_di" bpmnElement="Activity_B">
+        <dc:Bounds x="820" y="440" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ebr62n_di" bpmnElement="Activity_C">
+        <dc:Bounds x="820" y="550" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mhvq0l_di" bpmnElement="Activity_A">
+        <dc:Bounds x="820" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mdcz4r_di" bpmnElement="Event_EndA">
+        <dc:Bounds x="962" y="342" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="967" y="385" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0sfuiu4_di" bpmnElement="Event_EndB">
+        <dc:Bounds x="962" y="462" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="967" y="505" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ohlzoq_di" bpmnElement="Event_EndC">
+        <dc:Bounds x="962" y="572" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="966" y="615" width="28" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1lhi4zo_di" bpmnElement="Activity_Pre">
+        <dc:Bounds x="240" y="440" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0akdlv7_di" bpmnElement="Gateway_Split">
+        <dc:Bounds x="395" y="455" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="337" y="433" width="66" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1vpydbe_di" bpmnElement="Gateway_MergeSplit">
+        <dc:Bounds x="675" y="455" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="605" y="466" width="51" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/models/A02k - Inc GW Merge and Resplit - GRExps_0.bpmn
+++ b/test/models/A02k - Inc GW Merge and Resplit - GRExps_0.bpmn
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:apex="https://flowsforapex.org" id="Definitions_1wzb475" targetNamespace="http://bpmn.io/schema/b" exporter="Flows for APEX" exporterVersion="22.2.0">
+  <bpmn:process id="Process_12i" name="Test Model 12i - Merge Split Inc Gateways" isExecutable="false" apex:isCallable="false" apex:manualInput="false">
+    <bpmn:startEvent id="Event_Start" name="Start">
+      <bpmn:outgoing>Flow_194r471</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_194r471" sourceRef="Event_Start" targetRef="Activity_Pre" />
+    <bpmn:inclusiveGateway id="Gateway_Split" name="Gateway Split">
+      <bpmn:incoming>Flow_0wbb8yo</bpmn:incoming>
+      <bpmn:outgoing>Flow_X</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Y</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:task id="Activity_X" name="X">
+      <bpmn:incoming>Flow_X</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xmwnsp</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_X" name=":F4A$GW_Split_Var like &#39;%X%&#39;" sourceRef="Gateway_Split" targetRef="Activity_X" apex:sequence="20">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlExpression">:F4A$GW_Split_Var like '%X%'</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0xmwnsp" sourceRef="Activity_X" targetRef="Gateway_MergeSplit" />
+    <bpmn:inclusiveGateway id="Gateway_MergeSplit" name="Gateway MergeSplit">
+      <bpmn:incoming>Flow_0xmwnsp</bpmn:incoming>
+      <bpmn:incoming>Flow_01prxwy</bpmn:incoming>
+      <bpmn:outgoing>Flow_B</bpmn:outgoing>
+      <bpmn:outgoing>Flow_C</bpmn:outgoing>
+      <bpmn:outgoing>Flow_A</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:task id="Activity_Y" name="Y">
+      <bpmn:incoming>Flow_Y</bpmn:incoming>
+      <bpmn:outgoing>Flow_01prxwy</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_Y" name=":F4A$GW_Split_Var like &#39;%Y%&#39;" sourceRef="Gateway_Split" targetRef="Activity_Y" apex:sequence="30">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlExpression">:F4A$GW_Split_Var like '%Y%'</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_01prxwy" sourceRef="Activity_Y" targetRef="Gateway_MergeSplit" />
+    <bpmn:task id="Activity_B" name="B">
+      <bpmn:incoming>Flow_B</bpmn:incoming>
+      <bpmn:outgoing>Flow_1x0kegj</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_B" name=":F4A$GW_ReSplit_Var like &#39;%B%&#39;" sourceRef="Gateway_MergeSplit" targetRef="Activity_B" apex:sequence="30">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlExpression">:F4A$GW_ReSplit_Var like '%B%'</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:task id="Activity_C" name="C">
+      <bpmn:incoming>Flow_C</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xhau1w</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_C" name=":F4A$GW_ReSplit_Var like &#39;%C%&#39;" sourceRef="Gateway_MergeSplit" targetRef="Activity_C" apex:sequence="40">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlExpression">:F4A$GW_ReSplit_Var like '%C%'</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:task id="Activity_A" name="A">
+      <bpmn:incoming>Flow_A</bpmn:incoming>
+      <bpmn:outgoing>Flow_08ltn03</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_A" name=":F4A$GW_ReSplit_Var like &#39;%A%&#39;" sourceRef="Gateway_MergeSplit" targetRef="Activity_A" apex:sequence="10">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlExpression" sequence="10">:F4A$GW_ReSplit_Var like '%A%'</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_EndA" name="EndA">
+      <bpmn:incoming>Flow_08ltn03</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_08ltn03" sourceRef="Activity_A" targetRef="Event_EndA" />
+    <bpmn:endEvent id="Event_EndB" name="EndB">
+      <bpmn:incoming>Flow_1x0kegj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1x0kegj" sourceRef="Activity_B" targetRef="Event_EndB" />
+    <bpmn:endEvent id="Event_EndC" name="EndC">
+      <bpmn:incoming>Flow_1xhau1w</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1xhau1w" sourceRef="Activity_C" targetRef="Event_EndC" />
+    <bpmn:task id="Activity_Pre" name="Activity_Pre">
+      <bpmn:incoming>Flow_194r471</bpmn:incoming>
+      <bpmn:outgoing>Flow_0wbb8yo</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0wbb8yo" sourceRef="Activity_Pre" targetRef="Gateway_Split" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_12i">
+      <bpmndi:BPMNEdge id="Flow_0wbb8yo_di" bpmnElement="Flow_0wbb8yo">
+        <di:waypoint x="340" y="480" />
+        <di:waypoint x="395" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nw9ma2_di" bpmnElement="Flow_A">
+        <di:waypoint x="725" y="480" />
+        <di:waypoint x="750" y="480" />
+        <di:waypoint x="750" y="360" />
+        <di:waypoint x="890" y="360" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="757" y="333" width="87" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18utc2b_di" bpmnElement="Flow_C">
+        <di:waypoint x="725" y="480" />
+        <di:waypoint x="750" y="480" />
+        <di:waypoint x="750" y="590" />
+        <di:waypoint x="890" y="590" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="786" y="563" width="87" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nowoj9_di" bpmnElement="Flow_B">
+        <di:waypoint x="725" y="480" />
+        <di:waypoint x="890" y="480" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="769" y="446" width="87" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01prxwy_di" bpmnElement="Flow_01prxwy">
+        <di:waypoint x="660" y="590" />
+        <di:waypoint x="700" y="590" />
+        <di:waypoint x="700" y="505" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1k4vll4_di" bpmnElement="Flow_Y">
+        <di:waypoint x="420" y="505" />
+        <di:waypoint x="420" y="590" />
+        <di:waypoint x="560" y="590" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="439" y="545" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xmwnsp_di" bpmnElement="Flow_0xmwnsp">
+        <di:waypoint x="660" y="390" />
+        <di:waypoint x="700" y="390" />
+        <di:waypoint x="700" y="455" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1czj7yc_di" bpmnElement="Flow_X">
+        <di:waypoint x="420" y="455" />
+        <di:waypoint x="420" y="390" />
+        <di:waypoint x="560" y="390" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="439" y="346" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_194r471_di" bpmnElement="Flow_194r471">
+        <di:waypoint x="178" y="480" />
+        <di:waypoint x="240" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1x0kegj_di" bpmnElement="Flow_1x0kegj">
+        <di:waypoint x="990" y="480" />
+        <di:waypoint x="1032" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xhau1w_di" bpmnElement="Flow_1xhau1w">
+        <di:waypoint x="990" y="590" />
+        <di:waypoint x="1032" y="590" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="912" y="572" width="28" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08ltn03_di" bpmnElement="Flow_08ltn03">
+        <di:waypoint x="990" y="360" />
+        <di:waypoint x="1032" y="360" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_083kw68_di" bpmnElement="Event_Start">
+        <dc:Bounds x="142" y="462" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="149" y="505" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0mibtpu_di" bpmnElement="Gateway_Split">
+        <dc:Bounds x="395" y="455" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="337" y="433" width="66" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1e99cbp_di" bpmnElement="Gateway_MergeSplit">
+        <dc:Bounds x="675" y="455" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="605" y="466" width="51" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1lhi4zo_di" bpmnElement="Activity_Pre">
+        <dc:Bounds x="240" y="440" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08fxb0u_di" bpmnElement="Activity_X">
+        <dc:Bounds x="560" y="350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0sexfio_di" bpmnElement="Activity_Y">
+        <dc:Bounds x="560" y="550" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cc3rtq_di" bpmnElement="Activity_B">
+        <dc:Bounds x="890" y="440" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ebr62n_di" bpmnElement="Activity_C">
+        <dc:Bounds x="890" y="550" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mhvq0l_di" bpmnElement="Activity_A">
+        <dc:Bounds x="890" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mdcz4r_di" bpmnElement="Event_EndA">
+        <dc:Bounds x="1032" y="342" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1038" y="385" width="26" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0sfuiu4_di" bpmnElement="Event_EndB">
+        <dc:Bounds x="1032" y="462" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1038" y="505" width="26" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ohlzoq_di" bpmnElement="Event_EndC">
+        <dc:Bounds x="1032" y="572" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1037" y="615" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/models/import.json
+++ b/test/models/import.json
@@ -61,7 +61,27 @@
         "dgrm_status": "draft",
         "dgrm_category": "Testing",
         "file": "A02h - Event Based Gateway_0.bpmn"
-    },
+    },  {
+        "dgrm_name": "A02i - Inc GW Merge and Resplit",
+        "dgrm_version": "0",
+        "dgrm_status": "draft",
+        "dgrm_category": "Testing",
+        "file": "A02i - Inc GW Merge and Resplit_0.bpmn"
+      },
+      {
+        "dgrm_name": "A02j - Par GW Merge and Resplit",
+        "dgrm_version": "0",
+        "dgrm_status": "draft",
+        "dgrm_category": "Testing",
+        "file": "A02j - Par GW Merge and Resplit_0.bpmn"
+      },
+      {
+        "dgrm_name": "A02k - Inc GW Merge and Resplit - GRExps",
+        "dgrm_version": "0",
+        "dgrm_status": "draft",
+        "dgrm_category": "Testing",
+        "file": "A02k - Inc GW Merge and Resplit - GRExps_0.bpmn"
+      }
     {
         "dgrm_name": "A03a - Model with No Start Event",
         "dgrm_version": "0",

--- a/test/plsql/test_002_gateway.pks
+++ b/test/plsql/test_002_gateway.pks
@@ -46,8 +46,30 @@ create or replace package test_002_gateway is
    --%test(f4. inclusive gateway - GR var provided - jumbled CASE)
    procedure inclusive_route_provided_jumbled_case;
 
-   --%test(g. parallel gateway)
+   --%test(f5. inclusive gateway - merge and resplit - all paths)
+   procedure inclusive_merge_resplit_f5;
+
+   --%test(f6. inclusive gateway - merge and resplit - some paths a)
+   procedure inclusive_merge_resplit_f6;
+
+   --%test(f7. inclusive gateway - merge and resplit - some paths b)
+   procedure inclusive_merge_resplit_f7;
+
+   --%test(f8. inclusive gateway - merge and resplit - exprs - all paths)
+   procedure inclusive_merge_resplit_f8;
+
+   --%test(f9. inclusive gateway - merge and resplit - exprs - some paths a)
+   procedure inclusive_merge_resplit_f9;
+
+   --%test(f10. inclusive gateway - merge and resplit - exprs - some paths b)
+   procedure inclusive_merge_resplit_f10;
+
+
+   --%test(g1. parallel gateway)
    procedure parallel;
+
+  --%test(g2. parallel gateway - merge and resplit)
+   procedure parallel_merge_resplit;
 
    --%test (h. event based gateway - uses timer)
    procedure event_based;


### PR DESCRIPTION
- bug was introduced in v22.2 development
- for a respiting gateway, the incoming sub flow rather than the parent sub flow id was being used for the subsequent split
- added regression for inc gw with routing variables and expressions and for par gw to prevent this reoccurring
- no doc impact
- delete branch after merging