### PR TITLE
Add FKs to flow_instance_diagrams

### DIFF
--- a/src/ddl/install_scratch.sql
+++ b/src/ddl/install_scratch.sql
@@ -260,10 +260,18 @@ ALTER TABLE flow_subflows
         REFERENCES flow_processes ( prcs_id )
             ON DELETE CASCADE;
 
--- instance_diagrams - to add??
--- fk to flow_processes delete cascade
--- fk to diagram delete restrict
--- fk to calling dgrm delete restrict
+ALTER TABLE flow_instance_diagrams
+    ADD CONSTRAINT prdg_prcs_fk FOREIGN KEY ( prdg_prcs_id )
+        REFERENCES flow_processes ( prcs_id )
+            ON DELETE CASCADE;
+
+ALTER TABLE flow_instance_diagrams
+    ADD CONSTRAINT prdg_dgrm_fk FOREIGN KEY ( prdg_dgrm_id )
+        REFERENCES flow_diagrams ( dgrm_id );
+
+ALTER TABLE flow_instance_diagrams
+    ADD CONSTRAINT prdg_calling_dgrm_fk FOREIGN KEY ( prdg_calling_dgrm )
+        REFERENCES flow_diagrams ( dgrm_id );
 
 ALTER TABLE flow_timers
     ADD CONSTRAINT timr_prcs_fk FOREIGN KEY ( timr_prcs_id )

--- a/src/migrations/22.1_to_22.2/feature-172.sql
+++ b/src/migrations/22.1_to_22.2/feature-172.sql
@@ -84,6 +84,18 @@ I haven’t written the migration script but wanted to record what is required s
 COMMENT ON COLUMN flow_instance_diagrams.prdg_prdg_id is
     'Parent prdg_id (prdg_id of Calling Diagram)';
 
+ALTER TABLE flow_instance_diagrams
+    ADD CONSTRAINT prdg_prcs_fk FOREIGN KEY ( prdg_prcs_id )
+        REFERENCES flow_processes ( prcs_id )
+            ON DELETE CASCADE;
+
+ALTER TABLE flow_instance_diagrams
+    ADD CONSTRAINT prdg_dgrm_fk FOREIGN KEY ( prdg_dgrm_id )
+        REFERENCES flow_diagrams ( dgrm_id );
+
+ALTER TABLE flow_instance_diagrams
+    ADD CONSTRAINT prdg_calling_dgrm_fk FOREIGN KEY ( prdg_calling_dgrm )
+        REFERENCES flow_diagrams ( dgrm_id );
 
 -- add a row into here for each existing instance (all of which don't have callactivities)
 


### PR DESCRIPTION
- adds 3 FKs to flow_instance_diagrams to ensure that we don't get orphan prdg records, and that diagrams (calling or called) can't be deleted underneath a live instance.
- passes regression
- added to new database and feature migration script
- delete branch after merging