### PR TITLE
remove timer reenabling

### DIFF
--- a/src/migrate_db.sql
+++ b/src/migrate_db.sql
@@ -33,11 +33,8 @@ order by object_type
        , object_name
 ;
 
-PROMPT >> Resume DBMS_SCHEDULER job
-begin
-  flow_timers_pkg.enable_scheduled_job;
-end;
-/
+PROMPT >> Please make sure your Flows for APEX installation configuration is correct.
+PROMPT >> Check our migration guide in the docs for any post-installation tasks.
 
 PROMPT >> =====================
 PROMPT >> Upgrade Finished


### PR DESCRIPTION
Would be too dangerous to keep,
as configuration needs to be updated before any timers fire.