### PR TITLE
Fix #518

### DIFF
--- a/src/data/install_engine_messages_en.sql
+++ b/src/data/install_engine_messages_en.sql
@@ -226,7 +226,9 @@ begin
     values ( 'apex-task-multiple-processes', c_load_lang, q'[Error creating APEX session.  BPMN diagram contains multiple Process objects.]' );
   insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
     values ( 'call-diagram-not-callable', c_load_lang, q'[You tried to call a diagram %0 that is marked as being not callable.]' );
-  
+  -- below here manually added for 23.1 dev
+  insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+    values ( 'diagram-archive-has-instances', c_load_lang, q'[You tried to archive a diagram that has running instances.]' );  
   commit;
 end;
 /

--- a/src/data/json/engine_messages_de.json
+++ b/src/data/json/engine_messages_de.json
@@ -520,6 +520,11 @@
       "text_key": "workspace-not-found",
       "source": "Process %0: ServiceTask %1 failed: unable to find the workspace associated with the application id defined in the diagram. Please check the model.",
       "target": "Prozess %0: Aufgabe %1 fehlgeschlagen: Der, zu der Applikations-ID, zugewiesene Workspace konnte nicht gefunden werden. Bitte überprüfen sie das Modell"
+    },
+    {
+      "text_key" : "diagram-archive-has-instances",
+      "source" : "You tried to archive a diagram that has running instances.",
+      "target" : "You tried to archive a diagram that has running instances."
     }
   ]
 }

--- a/src/data/json/engine_messages_en.json
+++ b/src/data/json/engine_messages_en.json
@@ -520,6 +520,12 @@
   "text_key" : "call-diagram-not-callable",
   "source" : "You tried to call a diagram %0 that is marked as being not callable.",
   "target" : "You tried to call a diagram %0 that is marked as being not callable."
+},
+{
+  "text_key" : "diagram-archive-has-instances",
+  "source" : "You tried to archive a diagram that has running instances.",
+  "target" : "You tried to archive a diagram that has running instances."
 }
+
 ]
 }

--- a/src/data/json/engine_messages_es.json
+++ b/src/data/json/engine_messages_es.json
@@ -520,6 +520,11 @@
       "text_key": "call-diagram-not-callable",
       "source": "You tried to call a diagram %0 that is marked as being not callable.",
       "target": "Ha intentado llamar a un diagrama %0 marcado como no llamable."
+    },
+    {
+      "text_key" : "diagram-archive-has-instances",
+      "source" : "You tried to archive a diagram that has running instances.",
+      "target" : "You tried to archive a diagram that has running instances."
     }
   ]
 }

--- a/src/data/json/engine_messages_fr.json
+++ b/src/data/json/engine_messages_fr.json
@@ -520,6 +520,11 @@
       "text_key": "apex-task-not-found",
       "source": "APEX Workflow Task %0 not found in Flows for APEX Process",
       "target": "Tâche de workflow APEX %0 introuvable dans les processus Flows for APEX"
+    },
+    {
+      "text_key" : "diagram-archive-has-instances",
+      "source" : "You tried to archive a diagram that has running instances.",
+      "target" : "You tried to archive a diagram that has running instances."
     }
   ]
 }

--- a/src/data/json/engine_messages_ja.json
+++ b/src/data/json/engine_messages_ja.json
@@ -520,6 +520,11 @@
       "text_key": "subProcess-no-start",
       "source": "Unable to find Sub-Process Start Event.",
       "target": "サブプロセス開始イベントが見つかりません。"
+    },
+    {
+      "text_key" : "diagram-archive-has-instances",
+      "source" : "You tried to archive a diagram that has running instances.",
+      "target" : "You tried to archive a diagram that has running instances."
     }
   ]
 }

--- a/src/data/json/engine_messages_pt-br.json
+++ b/src/data/json/engine_messages_pt-br.json
@@ -520,6 +520,11 @@
       "text_key": "call-diagram-not-callable",
       "source": "You tried to call a diagram %0 that is marked as being not callable.",
       "target": "Você tentou chamar um diagrama %0 marcado como não chamável."
+    },
+    {
+      "text_key" : "diagram-archive-has-instances",
+      "source" : "You tried to archive a diagram that has running instances.",
+      "target" : "You tried to archive a diagram that has running instances."
     }
   ]
 }


### PR DESCRIPTION
Closes out #518 by adding a server -side check that a diagram has no non-completed/non-terminated  instances still running before a model is put into 'archive' status.