### PR TITLE
Issues/issue 325 audit+purge

### DIFF
--- a/src/data/install_default_config_data.sql
+++ b/src/data/install_default_config_data.sql
@@ -4,9 +4,10 @@ begin
   insert into flow_configuration (cfig_key, cfig_value) values ('logging_hide_userid', 'false');
   insert into flow_configuration (cfig_key, cfig_value) values ('logging_language','en');
   insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_logs_after_prcs_completion_days','60');
-  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_daily_summaries_days','185');
-  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_monthly_summaries_months','9');
-  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_quarterly_summaries_months','60');
+  insert into flow_configuration (cfig_key, cfig_value) values ('logging_archive_instance_summaries','false');
+  insert into flow_configuration (cfig_key, cfig_value) values ('stats_retain_daily_summaries_days','185');
+  insert into flow_configuration (cfig_key, cfig_value) values ('stats_retain_monthly_summaries_months','9');
+  insert into flow_configuration (cfig_key, cfig_value) values ('stats_retain_quarterly_summaries_months','60');
   insert into flow_configuration (cfig_key, cfig_value) values ('engine_app_mode','production');
   -- put new systems into strict mode for step keys (migrated systems are in legacy mode)
   insert into flow_configuration (cfig_key, cfig_value) values ('duplicate_step_prevention','strict');

--- a/src/data/install_default_config_data.sql
+++ b/src/data/install_default_config_data.sql
@@ -3,6 +3,10 @@ begin
   insert into flow_configuration (cfig_key, cfig_value) values ('logging_level', 'standard');
   insert into flow_configuration (cfig_key, cfig_value) values ('logging_hide_userid', 'false');
   insert into flow_configuration (cfig_key, cfig_value) values ('logging_language','en');
+  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_logs_after_prcs_completion_days','60');
+  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_daily_summaries_days','185');
+  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_monthly_summaries_months','9');
+  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_quarterly_summaries_months','60');
   insert into flow_configuration (cfig_key, cfig_value) values ('engine_app_mode','production');
   -- put new systems into strict mode for step keys (migrated systems are in legacy mode)
   insert into flow_configuration (cfig_key, cfig_value) values ('duplicate_step_prevention','strict');

--- a/src/data/install_engine_messages_en.sql
+++ b/src/data/install_engine_messages_en.sql
@@ -229,6 +229,14 @@ begin
   -- below here manually added for 23.1 dev
   insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
     values ( 'diagram-archive-has-instances', c_load_lang, q'[You tried to archive a diagram that has running instances.]' );  
+  insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+    values ( 'apex-task-business-ref-null', c_load_lang, q'[Error creating Approval Task - Business Ref / System of Record Primary Key must be not null.]' ); 
+  insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+    values ( 'archive-destination-bad-json', c_load_lang, q'[Error in archive destination configuration parameter.  Parameter: %0]' ); 
+  insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+    values ( 'log-archive-error', c_load_lang, q'[Error archiving instance summary for Process Instance %0]' ); 
+
+
   commit;
 end;
 /

--- a/src/ddl/install_scratch.sql
+++ b/src/ddl/install_scratch.sql
@@ -95,13 +95,20 @@ CREATE TABLE flow_processes (
     prcs_start_ts       TIMESTAMP WITH TIME ZONE,
     prcs_complete_ts    TIMESTAMP WITH TIME ZONE,  
     prcs_due_on         TIMESTAMP WITH TIME ZONE,
+    prcs_archived_ts    TIMESTAMP WITH TIME ZONE,
     prcs_priority       NUMBER,
     prcs_last_update    TIMESTAMP WITH TIME ZONE,
     prcs_last_update_by VARCHAR2(255 CHAR)
 );
 
+comment on column flow_processes.prcs_start_ts is 
+ 'Timestamp for process start.  Resets if process instance is reset.';
+
 comment on column flow_processes.prcs_complete_ts is 
  'Timestamp for process end when instance is in states "completed" or "terminated".';
+
+  comment on column flow_processes.prcs_archived_ts is 
+ 'Timestamp for process archive.  Resets if process instance is reset. ';
 
 ALTER TABLE flow_processes ADD CONSTRAINT prcs_pk PRIMARY KEY ( prcs_id );
 

--- a/src/ddl/install_scratch.sql
+++ b/src/ddl/install_scratch.sql
@@ -92,9 +92,13 @@ CREATE TABLE flow_processes (
     prcs_status         VARCHAR2(20 CHAR) NOT NULL,
     prcs_init_ts        TIMESTAMP WITH TIME ZONE NOT NULL,
     prcs_init_by        VARCHAR2(255 CHAR),
+    prcs_complete_ts    TIMESTAMP WITH TIME ZONE,  
     prcs_last_update    TIMESTAMP WITH TIME ZONE,
     prcs_last_update_by VARCHAR2(255 CHAR)
 );
+
+comment on column flow_processes.prcs_complete_ts is 
+ 'Timestamp for process end when instance is in states "completed" or "terminated".';
 
 ALTER TABLE flow_processes ADD CONSTRAINT prcs_pk PRIMARY KEY ( prcs_id );
 

--- a/src/ddl/install_scratch.sql
+++ b/src/ddl/install_scratch.sql
@@ -517,7 +517,7 @@ create unique index flow_stsf_ix on flow_daily_stats (stsf_dgrm_id, stsf_objt_bp
 
 alter table flow_step_stats
     add constraint check_stsf_period_type
-      check ( stsf_period in ('DAY' ,'MONTH', 'QUARTER','YEAR') );
+      check ( stsf_period in ('DAY' , 'MTD', 'MONTH', 'QUARTER','YEAR') );
 
 /* Configurations & Error Messages Tables */
 
@@ -535,3 +535,26 @@ create table flow_messages
 );
 
 alter table flow_messages ADD CONSTRAINT fmsg_pk PRIMARY KEY ( fmsg_message_key, fmsg_lang );
+
+create table flow_stats_history
+( sths_id       number  GENERATED always AS IDENTITY ( START WITH 1 NOCACHE ORDER ) not null
+, sths_date     date
+, sths_status   varchar2(50 char)
+, sths_type     varchar2(20 char)
+, sths_errors   varchar2(4000 char)
+, sths_comments varchar2(4000 char)
+, sths_created_on systimestamp with time zone
+, sths_updated_on systimestamp with time zone
+, sths_updated_by varchar2(50 char)
+);
+
+create index flow_sths_ix on flow_stats_history (sths_date);
+
+alter table flow_stats_history
+  add constraint check_sths_status
+    check (sths_status in ('SUCCESS', 'ERROR') );
+
+alter table flow_stats_type
+  add constraint check_sths_type
+    check (sths_type in ('DAY', 'MONTH', 'MTD', 'QUARTER') );
+

--- a/src/ddl/install_scratch.sql
+++ b/src/ddl/install_scratch.sql
@@ -4,7 +4,7 @@
 --   type:      Oracle Database 12cR2
 
 -- edited by Richard Allen Feb 2022
--- (c) Copyright, Oracle Corporation and/or its associates.  2020-2022.
+-- (c) Copyright, Oracle Corporation and/or its associates.  2020-2023.
 
 
 -- predefined type, no DDL - SDO_GEOMETRY
@@ -92,6 +92,7 @@ CREATE TABLE flow_processes (
     prcs_status         VARCHAR2(20 CHAR) NOT NULL,
     prcs_init_ts        TIMESTAMP WITH TIME ZONE NOT NULL,
     prcs_init_by        VARCHAR2(255 CHAR),
+    prcs_start_ts       TIMESTAMP WITH TIME ZONE,
     prcs_complete_ts    TIMESTAMP WITH TIME ZONE,  
     prcs_due_on         TIMESTAMP WITH TIME ZONE,
     prcs_priority       NUMBER,
@@ -391,6 +392,8 @@ ALTER TABLE flow_object_expressions
     ADD CONSTRAINT expr_set_ck
       CHECK ( expr_set in ('beforeEvent', 'onEvent', 'beforeTask', 'afterTask', 'beforeSplit', 'afterMerge', 'inVariables', 'outVariables') );
 
+/* Event logging Tables */
+
 create table flow_flow_event_log
 ( lgfl_dgrm_id       		NUMBER NOT NULL
 , lgfl_dgrm_name     		VARCHAR2(150 CHAR) NOT NULL
@@ -411,6 +414,7 @@ create table flow_instance_event_log
 , lgpr_business_id			VARCHAR2(4000 char)
 , lgpr_prcs_event       	VARCHAR2(20 CHAR) NOT NULL
 , lgpr_timestamp     		TIMESTAMP WITH TIME ZONE NOT NULL
+, lgpr_duration             interval day(3) to second (3)
 , lgpr_user 				VARCHAR2(255 char)
 , lgpr_comment				VARCHAR2(2000 CHAR)
 , lgpr_error_info           VARCHAR2(2000 CHAR)
@@ -455,6 +459,67 @@ create table flow_variable_event_log
 );
 
 create index flow_lgvr_ix on flow_variable_event_log (lgvr_prcs_id, lgvr_scope, lgvr_var_name);
+
+/* Statistics Tables */
+
+create table flow_instance_stats
+( stpr_dgrm_id              number
+, stpr_period_start         date
+, stpr_period               varchar2(10 char)
+, stpr_created              number
+, stpr_started              number
+, stpr_error                number
+, stpr_completed            number
+, stpr_terminated           number
+, stpr_reset                number
+, stpr_duration_10pc_ivl    interval day(3) to second(0)
+, stpr_duration_50pc_ivl    interval day(3) to second(0)
+, stpr_duration_90pc_ivl    interval day(3) to second(0)
+, stpr_duration_max_ivl     interval day(3) to second(0)
+, stpr_duration_10pc_sec    number
+, stpr_duration_50pc_sec    number
+, stpr_duration_90pc_sec    number
+, stpr_duration_max_sec     number
+);
+
+create unique index flow_stpr_ix on flow_instance_stats (stpr_dgrm_id, stpr_period, stpr_period_start);
+
+alter table flow_instance_stats
+    add constraint check_stpr_period_type
+      check ( stpr_period in ('DAY' ,'MONTH', 'QUARTER','YEAR') );
+
+create table flow_step_stats
+( stsf_dgrm_id             number
+, stsf_objt_bpmn_id        varchar2(50 char)
+, stsf_tag_name            varchar2(50 char)
+, stsf_period_start        date
+, stsf_period              varchar2(10 char)
+, stsf_completed           number
+, stsf_duration_10pc_ivl   interval day(3) to second(3)
+, stsf_duration_50pc_ivl   interval day(3) to second(3)
+, stsf_duration_90pc_ivl   interval day(3) to second(3)
+, stsf_duration_max_ivl    interval day(3) to second(3)
+, stsf_duration_10pc_sec   number
+, stsf_duration_50pc_sec   number
+, stsf_duration_90pc_sec   number
+, stsf_duration_max_sec    number
+, stsf_waiting_10pc_ivl    interval day(3) to second(3)
+, stsf_waiting_50pc_ivl    interval day(3) to second(3)
+, stsf_waiting_90pc_ivl    interval day(3) to second(3)
+, stsf_waiting_max_ivl     interval day(3) to second(3)
+, stsf_waiting_10pc_sec    number
+, stsf_waiting_50pc_sec    number
+, stsf_waiting_90pc_sec    number
+, stsf_waiting_max_sec     number
+);
+
+create unique index flow_stsf_ix on flow_daily_stats (stsf_dgrm_id, stsf_objt_bpmn_id, stsf_period, stsf_period_start);
+
+alter table flow_step_stats
+    add constraint check_stsf_period_type
+      check ( stsf_period in ('DAY' ,'MONTH', 'QUARTER','YEAR') );
+
+/* Configurations & Error Messages Tables */
 
 create table flow_configuration
 ( cfig_key                  varchar2(50 char) NOT NULL

--- a/src/migrations/22.2_to_23.1/feature-325.sql
+++ b/src/migrations/22.2_to_23.1/feature-325.sql
@@ -24,3 +24,38 @@
     set prcs_start_ts = prcs_init_ts 
   where prcs_start_ts is null
     and prcs_status != 'created';
+
+-- create table flow_stats_history
+
+create table flow_stats_history
+( sths_id       number GENERATED always AS IDENTITY ( START WITH 1 NOCACHE ORDER ) not null
+, sths_date     date
+, sths_status   varchar2(50 char)
+, sths_type     varchar2(20 char)
+, sths_errors   varchar2(4000 char)
+, sths_comments varchar2(4000 char)
+, sths_created_on systimestamp with time zone
+, sths_updated_on systimestamp with time zone
+, sths_updated_by varchar2(50 char)
+);
+
+create index flow_sths_ix on flow_stats_history (sths_date);
+
+alter table flow_stats_history
+  add constraint check_sths_status
+    check (sths_status in ('SUCCESS', 'ERROR') );
+
+alter table flow_stats_type
+  add constraint check_sths_type
+    check (sths_type in ('DAY', 'MONTH', 'QUARTER') );
+
+-- add stats tables
+
+-- add flow_instance_timeline views
+
+-- add retention config
+
+  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_logs_after_prcs_completion_days','60');
+  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_daily_summaries_days','185');
+  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_monthly_summaries_months','9');
+  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_quarterly_summaries_months','60');

--- a/src/migrations/22.2_to_23.1/feature-325.sql
+++ b/src/migrations/22.2_to_23.1/feature-325.sql
@@ -4,8 +4,23 @@
 
  alter table flow_processes
  add (
+  prcs_start_ts      timestamp with time zone,
   prcs_complete_ts   timestamp with time zone
  );
 
  comment on column flow_processes.prcs_complete_ts is 
  'Timestamp for process end when instance is in states "completed" or "terminated".';
+
+  comment on column flow_processes.prcs_start_ts is 
+ 'Timestamp for process start.  Resets if process instance is reset.';
+
+ alter table flow_instance_event_log 
+ add ( lgpr_duration interval day(3) to second (3));
+
+ -- approximate start_ts to instance creation_ts.   accurate unless instance has been reset
+ -- so should be good approximation for any production systems.
+
+ update flow_processes
+    set prcs_start_ts = prcs_init_ts 
+  where prcs_start_ts is null
+    and prcs_status != 'created';

--- a/src/migrations/22.2_to_23.1/feature-325.sql
+++ b/src/migrations/22.2_to_23.1/feature-325.sql
@@ -5,7 +5,8 @@
  alter table flow_processes
  add (
   prcs_start_ts      timestamp with time zone,
-  prcs_complete_ts   timestamp with time zone
+  prcs_complete_ts   timestamp with time zone,
+  prcs_archived_ts   timestamp with time zone
  );
 
  comment on column flow_processes.prcs_complete_ts is 
@@ -13,6 +14,9 @@
 
   comment on column flow_processes.prcs_start_ts is 
  'Timestamp for process start.  Resets if process instance is reset.';
+
+  comment on column flow_processes.prcs_archived_ts is 
+ 'Timestamp for process archive.  Resets if process instance is reset. ';
 
  alter table flow_instance_event_log 
  add ( lgpr_duration interval day(3) to second (3));
@@ -56,6 +60,7 @@ alter table flow_stats_type
 -- add retention config
 
   insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_logs_after_prcs_completion_days','60');
-  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_daily_summaries_days','185');
-  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_monthly_summaries_months','9');
-  insert into flow_configuration (cfig_key, cfig_value) values ('logging_retain_quarterly_summaries_months','60');
+  insert into flow_configuration (cfig_key, cfig_value) values ('logging_archive_instance_summaries','false');
+  insert into flow_configuration (cfig_key, cfig_value) values ('stats_retain_daily_summaries_days','185');
+  insert into flow_configuration (cfig_key, cfig_value) values ('stats_retain_monthly_summaries_months','9');
+  insert into flow_configuration (cfig_key, cfig_value) values ('stats_retain_quarterly_summaries_months','60');

--- a/src/migrations/22.2_to_23.1/feature-325.sql
+++ b/src/migrations/22.2_to_23.1/feature-325.sql
@@ -1,0 +1,11 @@
+
+
+ -- add completed_ts column to flow_processes
+
+ alter table flow_processes
+ add (
+  prcs_complete_ts   timestamp with time zone
+ );
+
+ comment on column flow_processes.prcs_complete_ts is 
+ 'Timestamp for process end when instance is in states "completed" or "terminated".';

--- a/src/plsql/flow_admin_api.pkb
+++ b/src/plsql/flow_admin_api.pkb
@@ -1,0 +1,62 @@
+create or replace package body flow_admin_api as
+ /* Flows for APEX - flow_admin_api.pkb
+--
+-- (c) Copyright Oracle Corporation and / or its affiliates, 2023.
+--
+-- Created    11-Feb-2023   Richard Allen, Oracle
+*/
+ /**
+FLOWS FOR APEX ADMIN API
+=========================
+
+The `flow_admin_api` package gives you access to the Flows for APEX engine admin procedures, and allows you to perform:
+-  Maintenance, Archiving and Purging of the Flows for APEX log files
+-  Maintenance, Archiving, and Purging of the Flows for APEX performance statistics all_summaries
+- Maintenance of Flows for APEX instance configuration parameters
+
+*/
+-- Log File Functions
+  procedure purge_instance_logs
+  ( p_retention_period_days  in number default null
+  ) 
+  is
+  begin
+    flow_log_admin.purge_instance_logs 
+    ( p_retention_period_days => p_retention_period_days 
+    );
+  end purge_instance_logs;
+
+  function instance_summary
+  ( p_process_id        in flow_processes.prcs_id%type
+  ) return clob
+  is
+  begin
+    return flow_log_admin.get_instance_json_summary ( p_process_id => p_process_id);
+  end instance_summary;
+
+  procedure archive_completed_instances
+  ( p_completed_before         in date default trunc(sysdate)
+  )
+  is
+  begin
+    flow_log_admin.archive_completed_instances
+    ( p_completed_before         => p_completed_before
+    );
+  end archive_completed_instances;
+
+-- Performance Summary Functions
+
+  procedure run_daily_stats
+  is
+  begin
+    flow_statistics.run_daily_stats;
+  end run_daily_stats;
+
+
+  procedure purge_statistics
+  is
+  begin
+    flow_statistics.purge_statistics;
+  end purge_statistics;
+
+end flow_admin_api;

--- a/src/plsql/flow_admin_api.pks
+++ b/src/plsql/flow_admin_api.pks
@@ -1,0 +1,40 @@
+create or replace package flow_admin_api
+   authid definer as
+ /* Flows for APEX - flow_admin_api.pks
+--
+-- (c) Copyright Oracle Corporation and / or its affiliates, 2023.
+--
+-- Created    11-Feb-2023   Richard Allen, Oracle
+*/
+ /**
+FLOWS FOR APEX ADMIN API
+=========================
+
+The `flow_admin_api` package gives you access to the Flows for APEX engine admin procedures, and allows you to perform:
+-  Maintenance, Archiving and Purging of the Flows for APEX log files
+-  Maintenance, Archiving, and Purging of the Flows for APEX performance statistics all_summaries
+- Maintenance of Flows for APEX instance configuration parameters
+
+*/
+-- Log File Functions
+
+
+  function instance_summary
+  ( p_process_id            in flow_processes.prcs_id%type
+  ) return clob;
+
+  procedure archive_completed_instances
+  ( p_completed_before      in date default trunc(sysdate)
+  );
+
+  procedure purge_instance_logs
+  ( p_retention_period_days  in number default null
+  );
+  
+-- Performance Summary Functions
+
+  procedure run_daily_stats;
+
+  procedure purge_statistics;
+
+end flow_admin_api;

--- a/src/plsql/flow_api_pkg.pkb
+++ b/src/plsql/flow_api_pkg.pkb
@@ -442,5 +442,18 @@ create or replace package body flow_api_pkg as
                                               );
   end return_approval_result;
 
+  function intervalDStoSec (
+    p_intervalDS  interval day to second
+  ) return number
+  is
+    l_sec number;
+  begin
+    return ( extract( day   from p_intervalDS) * 86400
+           + extract( hour  from p_intervalDS) *  3600
+           + extract(minute from p_intervalDS) *    60
+           + extract(second from p_intervalDS)        
+           );
+  end intervalDStoSec;
+
 end flow_api_pkg;
 /

--- a/src/plsql/flow_api_pkg.pks
+++ b/src/plsql/flow_api_pkg.pks
@@ -250,7 +250,7 @@ This example will delete the process instance that have the ID 1.
 
 ```sql
 begin
-   flow_api_pkg.flow_reset(
+   flow_api_pkg.flow_delete(
         p_process_id => 1
       , p_comment    => 'Delete Process Instance using the PL/SQL API'
    );
@@ -577,5 +577,9 @@ flow_api_pkg.return_approval_result ( p_process_id      => :PROCESS_ID,
                                       p_result          => :APEX$TASK_OUTCOME);
 ```
 **/
+  function intervalDStoSec (
+    p_intervalDS  interval day to second
+  ) return number;
+
 end flow_api_pkg;
 /

--- a/src/plsql/flow_call_activities.pkb
+++ b/src/plsql/flow_call_activities.pkb
@@ -177,7 +177,8 @@ as
         , p_objt_bpmn_id  => p_step_info.target_objt_ref
         , p_event         => flow_constants_pkg.gc_prcs_event_enter_call
         , p_comment       => 'Starting called diagram '||l_call_definition.dgrm_name||
-                             ' version '||l_call_definition.dgrm_version||'.'
+                             ' version '||l_call_definition.dgrm_version||
+                             ' in diagram level '||l_called_subflow_context.sbfl_id
         );
 
         if not flow_globals.get_step_error then 

--- a/src/plsql/flow_constants_pkg.pks
+++ b/src/plsql/flow_constants_pkg.pks
@@ -280,51 +280,57 @@ as
 
 -- Config Parameter Keys
 
-  gc_config_logging_level             constant varchar2(50 char) := 'logging_level';
-  gc_config_logging_hide_userid       constant varchar2(50 char) := 'logging_hide_userid';
-  gc_config_logging_language          constant varchar2(50 char) := 'logging_language';
-  gc_config_engine_app_mode           constant varchar2(50 char) := 'engine_app_mode';
-  gc_config_dup_step_prevention       constant varchar2(50 char) := 'duplicate_step_prevention';
-  gc_config_timer_max_cycles          constant varchar2(50 char) := 'timer_max_cycles';
-  gc_config_default_workspace         constant varchar2(50 char) := 'default_workspace';
-  gc_config_default_application       constant varchar2(50 char) := 'default_application';
-  gc_config_default_pageid            constant varchar2(50 char) := 'default_pageid';
-  gc_config_default_username          constant varchar2(50 char) := 'default_username';
-  gc_config_default_email_sender      constant varchar2(50 char) := 'default_email_sender';
-  gc_config_log_retain_logs           constant varchar2(50 char) := 'logging_retain_logs_after_prcs_completion_days';
-  gc_config_log_retain_summary_daily  constant varchar2(50 char) := 'logging_retain_daily_summaries_days';
-  gc_config_log_retain_summary_month  constant varchar2(50 char) := 'logging_retain_monthly_summaries_months';
-  gc_config_log_retain_summary_qtr    constant varchar2(50 char) := 'logging_retain_quarterly_summaries_months';
+  gc_config_logging_level               constant varchar2(50 char) := 'logging_level';
+  gc_config_logging_hide_userid         constant varchar2(50 char) := 'logging_hide_userid';
+  gc_config_logging_language            constant varchar2(50 char) := 'logging_language';
+  gc_config_logging_retain_logs         constant varchar2(50 char) := 'logging_retain_logs_after_prcs_completion_days';
+  gc_config_logging_archive_location    constant varchar2(50 char) := 'logging_archive_location';
+  gc_config_logging_archive_enabled     constant varchar2(50 char) := 'logging_archive_instance_summaries';
+  gc_config_engine_app_mode             constant varchar2(50 char) := 'engine_app_mode';
+  gc_config_dup_step_prevention         constant varchar2(50 char) := 'duplicate_step_prevention';
+  gc_config_timer_max_cycles            constant varchar2(50 char) := 'timer_max_cycles';
+  gc_config_default_workspace           constant varchar2(50 char) := 'default_workspace';
+  gc_config_default_application         constant varchar2(50 char) := 'default_application';
+  gc_config_default_pageid              constant varchar2(50 char) := 'default_pageid';
+  gc_config_default_username            constant varchar2(50 char) := 'default_username';
+  gc_config_default_email_sender        constant varchar2(50 char) := 'default_email_sender';
+  gc_config_stats_retain_summary_daily  constant varchar2(50 char) := 'stats_retain_daily_summaries_days';
+  gc_config_stats_retain_summary_month  constant varchar2(50 char) := 'stats_retain_monthly_summaries_months';
+  gc_config_stats_retain_summary_qtr    constant varchar2(50 char) := 'stats_retain_quarterly_summaries_months';
 
 
 -- Config Parameter Valid Values (when not true / false or numeric)
 
-  gc_config_logging_level_none         constant varchar2(2000 char) := 'none';      -- none
-  gc_config_logging_level_standard     constant varchar2(2000 char) := 'standard';  -- instances and tasks
-  gc_config_logging_level_secure       constant varchar2(2000 char) := 'secure';    -- standard + diagram changes
-  gc_config_logging_level_full         constant varchar2(2000 char) := 'full';      -- secure + variable changes
-  gc_config_engine_app_mode_dev        constant varchar2(2000 char) := 'development';
-  gc_config_engine_app_mode_prod       constant varchar2(2000 char) := 'production';
-  gc_config_dup_step_prevention_legacy constant varchar2(2000 char) := 'legacy';   -- null step key allowed
-  gc_config_dup_step_prevention_strict constant varchar2(2000 char) := 'strict';   -- step key enforced
+  gc_config_logging_level_none               constant varchar2(2000 char) := 'none';        -- none
+  gc_config_logging_level_standard           constant varchar2(2000 char) := 'standard';    -- instances and tasks
+  gc_config_logging_level_secure             constant varchar2(2000 char) := 'secure';      -- standard + diagram changes
+  gc_config_logging_level_full               constant varchar2(2000 char) := 'full';        -- secure + variable changes
+  gc_config_engine_app_mode_dev              constant varchar2(2000 char) := 'development';
+  gc_config_engine_app_mode_prod             constant varchar2(2000 char) := 'production';
+  gc_config_dup_step_prevention_legacy       constant varchar2(2000 char) := 'legacy';      -- null step key allowed
+  gc_config_dup_step_prevention_strict       constant varchar2(2000 char) := 'strict';      -- step key enforced
+  gc_config_archive_destination_table        constant varchar2(2000 char) := 'TABLE';       -- To Database Table
+  gc_config_archive_destination_oci_api      constant varchar2(2000 char) := 'OCI-API';     -- OCI using API Key
+  gc_config_archive_destination_oci_preauth  constant varchar2(2000 char) := 'OCI-PREAUTH'; -- OCI using PreAuth
 
 
 -- Config Parameter Default Values
 
-  gc_config_default_logging_level             constant varchar2(2000 char) := gc_config_logging_level_standard;
-  gc_config_default_logging_hide_userid       constant varchar2(2000 char) := 'false';
-  gc_config_default_logging_language          constant varchar2(2000 char) := 'en';
-  gc_config_default_engine_app_mode           constant varchar2(2000 char) := 'production';
-  gc_config_default_dup_step_prevention       constant varchar2(2000 char) := 'legacy';
-  gc_config_default_default_workspace         constant varchar2(2000 char) := 'FLOWS4APEX';
-  gc_config_default_default_application       constant varchar2(2000 char) := '100';
-  gc_config_default_default_pageID            constant varchar2(2000 char) := '1';
-  gc_config_default_default_username          constant varchar2(2000 char) := 'FLOWS4APEX';
-  gc_config_default_timer_max_cycles          constant varchar2(2000 char) := '1000';
-  gc_config_default_log_retain_logs           constant varchar2(2000 char) := '60';
-  gc_config_default_log_retain_summary_daily  constant varchar2(2000 char) := '180';
-  gc_config_default_log_retain_summary_month  constant varchar2(2000 char) := '9';
-  gc_config_default_log_retain_summary_qtr    constant varchar2(2000 char) := '36';
+  gc_config_default_logging_level               constant varchar2(2000 char) := gc_config_logging_level_standard;
+  gc_config_default_logging_hide_userid         constant varchar2(2000 char) := 'false';
+  gc_config_default_logging_language            constant varchar2(2000 char) := 'en';
+  gc_config_default_logging_archive_enabled     constant varchar2(2000 char) := 'false';
+  gc_config_default_engine_app_mode             constant varchar2(2000 char) := 'production';
+  gc_config_default_dup_step_prevention         constant varchar2(2000 char) := 'legacy';
+  gc_config_default_default_workspace           constant varchar2(2000 char) := 'FLOWS4APEX';
+  gc_config_default_default_application         constant varchar2(2000 char) := '100';
+  gc_config_default_default_pageID              constant varchar2(2000 char) := '1';
+  gc_config_default_default_username            constant varchar2(2000 char) := 'FLOWS4APEX';
+  gc_config_default_timer_max_cycles            constant varchar2(2000 char) := '1000';
+  gc_config_default_log_retain_logs             constant varchar2(2000 char) := '60';
+  gc_config_default_stats_retain_summary_daily  constant varchar2(2000 char) := '180';
+  gc_config_default_stats_retain_summary_month  constant varchar2(2000 char) := '9';
+  gc_config_default_stats_retain_summary_qtr    constant varchar2(2000 char) := '36';
 
 -- Staistics Period
   gc_stats_period_day                   constant varchar2(20 char) := 'DAY';

--- a/src/plsql/flow_constants_pkg.pks
+++ b/src/plsql/flow_constants_pkg.pks
@@ -291,6 +291,11 @@ as
   gc_config_default_pageid            constant varchar2(50 char) := 'default_pageid';
   gc_config_default_username          constant varchar2(50 char) := 'default_username';
   gc_config_default_email_sender      constant varchar2(50 char) := 'default_email_sender';
+  gc_config_log_retain_logs           constant varchar2(50 char) := 'logging_retain_logs_after_prcs_completion_days';
+  gc_config_log_retain_summary_daily  constant varchar2(50 char) := 'logging_retain_daily_summaries_days';
+  gc_config_log_retain_summary_month  constant varchar2(50 char) := 'logging_retain_monthly_summaries_months';
+  gc_config_log_retain_summary_qtr    constant varchar2(50 char) := 'logging_retain_quarterly_summaries_months';
+
 
 -- Config Parameter Valid Values (when not true / false or numeric)
 
@@ -316,6 +321,18 @@ as
   gc_config_default_default_pageID            constant varchar2(2000 char) := '1';
   gc_config_default_default_username          constant varchar2(2000 char) := 'FLOWS4APEX';
   gc_config_default_timer_max_cycles          constant varchar2(2000 char) := '1000';
+  gc_config_default_log_retain_logs           constant varchar2(2000 char) := '60';
+  gc_config_default_log_retain_summary_daily  constant varchar2(2000 char) := '180';
+  gc_config_default_log_retain_summary_month  constant varchar2(2000 char) := '9';
+  gc_config_default_log_retain_summary_qtr    constant varchar2(2000 char) := '36';
+
+-- Staistics Period
+  gc_stats_period_day                   constant varchar2(20 char) := 'DAY';
+  gc_stats_period_month                 constant varchar2(20 char) := 'MONTH';
+  gc_stats_period_quarter               constant varchar2(20 char) := 'QUARTER';
+
+  gc_stats_outcome_success              constant varchar2(50 char) := 'SUCCESS';
+  gc_stats_outcome_error                constant varchar2(50 char) := 'ERROR';
 
 
 

--- a/src/plsql/flow_engine.pkb
+++ b/src/plsql/flow_engine.pkb
@@ -229,6 +229,7 @@ end flow_process_link_event;
         update flow_processes prcs 
            set prcs.prcs_status         = l_process_end_status
              , prcs.prcs_last_update    = systimestamp
+             , prcs.prcs_complete_ts    = systimestamp
              , prcs.prcs_last_update_by = coalesce  ( sys_context('apex$session','app_user') 
                                                     , sys_context('userenv','os_user')
                                                     , sys_context('userenv','session_user')

--- a/src/plsql/flow_instances.pkb
+++ b/src/plsql/flow_instances.pkb
@@ -511,6 +511,7 @@ as
        set prcs.prcs_status         = flow_constants_pkg.gc_prcs_status_created
          , prcs_start_ts            = null
          , prcs_complete_ts         = null
+         , prcs_archived_ts         = null
          , prcs.prcs_last_update    = systimestamp
          , prcs.prcs_last_update_by = coalesce  ( sys_context('apex$session','app_user') 
                                                 , sys_context('userenv','os_user')
@@ -609,9 +610,15 @@ as
     , p_comment     in flow_instance_event_log.lgpr_comment%type default null
     )
   is
-    l_return_code   number;
+    l_return_code             number;
+    l_is_not_archived         boolean := false;
+    l_cur_prcs_id             flow_processes.prcs_id%type;
+    l_cur_sbfl_id             flow_subflows.sbfl_id%type;
+    l_cur_sflg_updated        flow_subflow_log.sflg_last_updated%type;
+    l_cur_prdg_id             flow_instance_diagrams.prdg_id%type;
+    l_cur_prcs_archived_ts    flow_processes.prcs_archived_ts%type;
     cursor c_lock_all is 
-      select prcs.prcs_id, sbfl.sbfl_id, sflg.sflg_last_updated, prdg.prdg_id
+      select prcs.prcs_id, sbfl.sbfl_id, sflg.sflg_last_updated, prdg.prdg_id, prcs.prcs_archived_ts
         from flow_subflows sbfl
         join flow_processes prcs
           on prcs.prcs_id = sbfl.sbfl_prcs_id 
@@ -630,9 +637,17 @@ as
     begin 
       -- lock all timers, logs, subflows, instance diagrams and the process
       open c_lock_all;
+      fetch c_lock_all into l_cur_prcs_id
+                          , l_cur_sbfl_id
+                          , l_cur_sflg_updated
+                          , l_cur_prdg_id
+                          , l_cur_prcs_archived_ts;
       flow_timers_pkg.lock_process_timers
       ( pi_prcs_id => p_process_id
       ); 
+      if l_cur_prcs_archived_ts is null then
+        l_is_not_archived := true;
+      end if;
       close c_lock_all; 
 
     exception 
@@ -655,8 +670,17 @@ as
         pi_prcs_id => p_process_id
       , po_return_code => l_return_code
     );  
+    -- if instance archiving is enabled and instance is not yet archived, run instance archive now before
+    -- process data is deleted from run time tables to ensure arcchive is full audit trail
+    if l_is_not_archived then
+      if flow_engine_util.get_config_value ( p_config_key => flow_constants_pkg.gc_config_logging_archive_enabled 
+                                           , p_default_value => flow_constants_pkg.gc_config_default_logging_archive_enabled
+                                           ) = 'true' 
+      then
+        flow_log_admin.archive_completed_instances (p_process_id => p_process_id);
+      end if;
+    end if;
     -- clear out run-time object_log
-
     delete
       from flow_subflow_log sflg 
      where sflg_prcs_id = p_process_id

--- a/src/plsql/flow_instances.pkb
+++ b/src/plsql/flow_instances.pkb
@@ -1,7 +1,7 @@
 /* 
 -- Flows for APEX - flow_instances.pkb
 -- 
--- (c) Copyright Oracle Corporation and / or its affiliates, 2022.
+-- (c) Copyright Oracle Corporation and / or its affiliates, 2022-2023.
 -- (c) Copyright MT AG, 2021-2022.
 --
 -- Created  25-May-2021  Richard Allen (Flowquest) for  MT AG  - refactor from flow_engine
@@ -338,6 +338,7 @@ as
     -- mark process as running
     update flow_processes prcs
        set prcs.prcs_status         = flow_constants_pkg.gc_prcs_status_running
+         , prcs.prcs_start_ts       = systimestamp
          , prcs.prcs_last_update    = systimestamp
          , prcs.prcs_last_update_by =  coalesce  ( sys_context('apex$session','app_user') 
                                                  , sys_context('userenv','os_user')
@@ -508,6 +509,8 @@ as
     -- reset the process status to 'created'
     update flow_processes prcs
        set prcs.prcs_status         = flow_constants_pkg.gc_prcs_status_created
+         , prcs_start_ts            = null
+         , prcs_complete_ts         = null
          , prcs.prcs_last_update    = systimestamp
          , prcs.prcs_last_update_by = coalesce  ( sys_context('apex$session','app_user') 
                                                 , sys_context('userenv','os_user')

--- a/src/plsql/flow_instances.pkb
+++ b/src/plsql/flow_instances.pkb
@@ -559,6 +559,7 @@ as
     update flow_processes prcs
        set prcs.prcs_status = flow_constants_pkg.gc_prcs_status_terminated
          , prcs.prcs_last_update = systimestamp
+         , prcs.prcs_complete_ts = systimestamp
          , prcs.prcs_last_update_by = coalesce  ( sys_context('apex$session','app_user') 
                                                 , sys_context('userenv','os_user')
                                                 , sys_context('userenv','session_user')

--- a/src/plsql/flow_log_admin.pkb
+++ b/src/plsql/flow_log_admin.pkb
@@ -1,0 +1,466 @@
+create or replace package body flow_log_admin as
+  /* 
+  -- Flows for APEX - flow_log_admin.pkb
+  -- 
+  -- (c) Copyright Oracle Corporation and / or its affiliates, 2023.
+
+  --
+  -- Created    18-Feb-2021  Richard Allen (Oracle)
+  --
+  -- Package flow_log_admin manaes the Flows for APEX log tables, including
+  --    - creation of instance archive summary
+  --    - archiving of instance logs
+  --    - purging of instance log tables 
+  */  
+
+  type t_archive_location is record
+  ( destination_type               flow_types_pkg.t_vc200
+  , db_table_name                  flow_types_pkg.t_vc200
+  , db_id_column                   flow_types_pkg.t_vc200
+  , db_blob_column                 flow_types_pkg.t_vc200
+  , oci_base_url                   flow_types_pkg.t_vc200
+  , oci_bucket_name                flow_types_pkg.t_vc200
+  , oci_document_prefix            flow_types_pkg.t_vc200
+  , oci_request_url                flow_types_pkg.t_vc200  -- url to use for request
+  , oci_credential_static_id       flow_types_pkg.t_vc200  -- APEX Static ID of Credential
+  );
+
+
+  function get_instance_json_summary
+  ( p_process_id     in flow_processes.prcs_id%type
+  ) return clob
+  is
+    l_archive_json    clob;
+  begin
+    with p as
+       (  select prcs_id
+               , prcs_dgrm_id
+               , prcs_name
+               , prcs_priority
+               , prcs_status
+               , prcs_init_ts
+               , prcs_init_by
+               , prcs_due_on
+          from   flow_processes prcs
+          where  prcs_id = p_process_id               
+      ),
+     s as
+        ( select distinct sc.lgvr_scope scope, sc.lgvr_prcs_id
+          from   flow_variable_event_log sc
+        )
+    select json_object (
+       'processID'    value p.prcs_id,
+       'mainDiagram'  value p.prcs_dgrm_id,
+       'processName'  value p.prcs_name,
+       'businessID'   value prov.prov.prov_var_vc2,
+       'priority'     value p.prcs_priority,
+       'prcs_status'  value p.prcs_status,
+       'prcs_init_ts' value p.prcs_init_ts,
+       'prcs_init_by' value p.prcs_init_by,
+       'prcs_due_on'  value p.prcs_due_on,
+       'json_created' value systimestamp,
+       'diagramsUsed' value
+            (select json_arrayagg 
+                       ( json_object 
+                           (
+                           'diagramLevel'               value prdg_diagram_level,
+                           'diagramId'                  value prdg_dgrm_id,
+                           'diagramName'                value dgrm_name,
+                           'diagramVersion'             value dgrm_version,
+                           'diagramStatus'              value dgrm_status,
+                           'callingDiagram'             value prdg_calling_dgrm,
+                           'callingObject'              value prdg_calling_objt
+                           ) order by prdg_diagram_level asc 
+                       returning clob)
+               from flow_instance_diagrams prdg
+               join flow_diagrams dgrm
+                 on dgrm.dgrm_id = prdg.prdg_dgrm_id
+              where prdg.prdg_prcs_id = p.prcs_id   
+           ),
+       'events' : 
+           (select json_arrayagg 
+                       ( json_object 
+                           (
+                           'event'                      value lgpr_prcs_event,
+                           'object'                     value lgpr_objt_id,
+                           'diagram'                    value lgpr_dgrm_id,
+                           'timestamp'                  value lgpr_timestamp,
+                           'user'                       value lgpr_user,
+                           'error-info'                 value lgpr_error_info,
+                           'comment'                    value lgpr_comment absent on null
+                           ) order by lgpr_timestamp 
+                        returning clob )
+              from flow_instance_event_log lgpr
+             where lgpr.lgpr_prcs_id = p.prcs_id
+           ),       
+       'steps' :
+           (select json_arrayagg
+                       (json_object 
+                           (
+                           'object'                     value lgsf_objt_id,
+                           'subflowID'                  value lgsf_sbfl_id,
+                           'processLevel'               value lgsf_sbfl_process_level,
+                           'priority'                   value lgsf_priority,
+                           'lastCompleted'              value lgsf_last_completed,
+                           'wasCurrent'                 value lgsf_was_current,
+                           'wasStarted'                 value lgsf_started,
+                           'wasCompleted'               value lgsf_completed,
+                           'statusWhenComplete'         Value lgsf_status_when_complete,
+                           'subflowDiagram'             value lgsf_sbfl_dgrm_id,
+                           'reservation'                value lgsf_reservation,
+                           'user'                       value lgsf_user,
+                           'comment'                    value lgsf_comment absent on null
+                           ) order by lgsf_was_current
+                       returning clob )
+             from flow_step_event_log lgsf
+            where lgsf.lgsf_prcs_id = p.prcs_id
+            ),
+       'processVariablesSet' :
+               (  select json_arrayagg (
+                       json_object (
+                           'scope'         value s.scope,
+                           'variables'     value
+                               ( select json_arrayagg 
+                                           (
+                                           json_object 
+                                               (
+                                               'var_name'        value lgvr.lgvr_var_name,
+                                               'subflowID'       value lgvr.lgvr_sbfl_id,
+                                               'objectId'        value lgvr.lgvr_objt_id,
+                                               'expr_set'        value lgvr.lgvr_expr_set,
+                                               'type'            value lgvr.lgvr_var_type,
+                                               'timestamp'       value lgvr.lgvr_timestamp,
+                                               'newValue'        value case lgvr.lgvr_var_type
+                                                          when 'VARCHAR2'                   then lgvr.lgvr_var_vc2
+                                                          when 'NUMBER'                     then to_char(lgvr.lgvr_var_num)
+                                                          when 'DATE'                       then to_char(lgvr.lgvr_var_date,'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+                                                          when 'TIMESTAMP WITH TIME ZONE'   then to_char(lgvr.lgvr_var_tstz,'YYYY-MM-DD"T"HH24:MI:SSTZR')
+                                                          when 'CLOB'                       then 'CLOB Value'
+                                                          end 
+                                               )
+                                           order by lgvr.lgvr_timestamp 
+                                           returning clob )
+                                   from flow_variable_event_log lgvr
+                                  where lgvr.lgvr_prcs_id = p.prcs_id
+                                    and lgvr.lgvr_scope   = s.scope
+                               ) returning clob
+                           )
+                       returning clob )
+                   from s
+                  where s.lgvr_prcs_id = p.prcs_id
+               )
+           returning clob )
+     into l_archive_json
+     from p 
+     left join flow_process_variables prov
+       on prov.prov_prcs_id    = p.prcs_id
+      and prov.prov_var_name   = 'BUSINESS_REF'
+      and prov.prov_scope      = 0
+    ;
+    return l_archive_json;
+  end get_instance_json_summary;
+
+  procedure purge_instance_logs
+  ( p_retention_period_days  in number default null
+  )
+  is
+    l_log_retain_days    flow_configuration.cfig_value%type;
+    l_purge_interval     interval day(4) to second(0);
+  begin
+    apex_debug.enter ('purge_instance_logs'
+    , 'p_retention_period_days', p_retention_period_days);
+
+    -- if retention period not specified, get configuration parameter or default
+    if p_retention_period_days is null then
+      l_log_retain_days     := flow_engine_util.get_config_value 
+                               ( p_config_key  => flow_constants_pkg.gc_config_logging_retain_logs
+                               , p_default_value  => flow_constants_pkg.gc_config_default_log_retain_logs
+                               );   
+      l_purge_interval   := to_dsinterval ('P'||trim( both from l_log_retain_days)||'D');
+    else
+      l_purge_interval   := to_dsinterval ('P'||trim( both from p_retention_period_days)||'D');   
+    end if;
+    -- delete
+    delete from flow_variable_event_log
+    where lgvr_prcs_id in (select lgpr_prcs_id
+                           from   flow_instance_event_log
+                           where  lgpr_prcs_event = flow_constants_pkg.gc_prcs_event_completed
+                           and    lgpr_timestamp < systimestamp - l_purge_interval);
+
+
+    delete from flow_step_event_log
+    where lgsf_prcs_id in (select lgpr_prcs_id
+                           from   flow_instance_event_log
+                           where  lgpr_prcs_event = flow_constants_pkg.gc_prcs_event_completed
+                           and    lgpr_timestamp < systimestamp - l_purge_interval);
+
+    delete from flow_instance_event_log
+    where lgpr_prcs_id in (select lgpr_prcs_id
+                           from   flow_instance_event_log
+                           where  lgpr_prcs_event = flow_constants_pkg.gc_prcs_event_completed
+                           and    lgpr_timestamp < systimestamp - l_purge_interval);
+
+  end purge_instance_logs;
+
+
+  /*function validate_db_archive_location
+  ( p_table       flow_types_pkg.t_vc200
+  , p_id_column   flow_types_pkg.t_vc200
+  , p_blob_column flow_types_pkg.t_vc200
+  ) return boolean -- true if validated
+  is
+  begin
+    begin
+      select 
+  end validate_db_archive_location;*/
+
+  function get_archive_location
+  return t_archive_location
+  is
+    l_archive_location              t_archive_location;
+    e_archive_bad_destination_json  exception;
+    l_destination_json              flow_configuration.cfig_value%type;
+  begin
+    apex_debug.enter ( 'get_archive_location');
+
+    l_destination_json      := flow_engine_util.get_config_value 
+                             ( p_config_key  => flow_constants_pkg.gc_config_logging_archive_location
+                             , p_default_value  => null);
+
+    apex_debug.message 
+    ( p_message => 'Retrieved configuration parameter %0 contents %1'
+    , p0 => flow_constants_pkg.gc_config_logging_archive_location
+    , p1 => l_destination_json
+    );                         
+
+    apex_json.parse (p_source => l_destination_json);
+
+    l_archive_location.destination_type            := apex_json.get_varchar2 (p_path => 'destinationType');
+
+    apex_debug.message (p_message => '--- Destination Type : %0', p0=> l_archive_location.destination_type);  
+
+    case l_archive_location.destination_type 
+    when flow_constants_pkg.gc_config_archive_destination_table then
+      l_archive_location.db_table_name             := apex_json.get_varchar2 (p_path => 'tableDetails.tableName');
+      l_archive_location.db_id_column              := apex_json.get_varchar2 (p_path => 'tableDetails.idColumn');
+      l_archive_location.db_blob_column            := apex_json.get_varchar2 (p_path => 'tableDetails.blobColumn');
+
+    when flow_constants_pkg.gc_config_archive_destination_oci_api then
+      l_archive_location.oci_base_url              := apex_json.get_varchar2 (p_path => 'ociApiDetails.baseUrl');
+      apex_debug.message (p_message => '--- Base URL : %0', p0=> l_archive_location.oci_base_url);  
+      l_archive_location.oci_bucket_name           := apex_json.get_varchar2 (p_path => 'ociApiDetails.bucketName');
+      apex_debug.message (p_message => '--- Bucket Name : %0', p0=> l_archive_location.oci_bucket_name);
+      l_archive_location.oci_document_prefix       := apex_json.get_varchar2 (p_path => 'ociApiDetails.documentPrefix');
+      l_archive_location.oci_credential_static_id  := apex_json.get_varchar2 (p_path => 'ociApiDetails.credentialApexStaticId');
+
+      l_archive_location.oci_request_url :=  l_archive_location.oci_base_url
+                                         || 'b/' 
+                                         || l_archive_location.oci_bucket_name 
+                                         || '/o/';
+      apex_debug.message (p_message => '--- Request URL : %0', p0=> l_archive_location.oci_request_url);
+    when flow_constants_pkg.gc_config_archive_destination_oci_preauth then
+      l_archive_location.oci_request_url           := apex_json.get_varchar2 (p_path => 'ociPreAuthDetails.preAuthUrl');
+      apex_debug.message (p_message => '--- Request URL : %0', p0=> l_archive_location.oci_request_url);
+      l_archive_location.oci_document_prefix       := apex_json.get_varchar2 (p_path => 'ociPreAuthDetails.documentPrefix');
+      l_archive_location.oci_credential_static_id  := apex_json.get_varchar2 (p_path => 'ociPreAuthDetails.credentialApexStaticId');
+    end case;
+    return l_archive_location;
+    exception
+      when others then 
+        apex_debug.info 
+        ( p_message => ' --- Error in %0 configuration parameter definition. Value :'
+        , p0  => flow_constants_pkg.gc_config_logging_archive_location
+        , p1  => l_destination_json
+        );
+        flow_errors.handle_general_error
+        ( pi_message_key    => 'archive-destination-bad-json'
+        , p0 => l_destination_json
+        );  
+        -- $F4AMESSAGE 'archive-destination-bad-json' || 'Error in archive destination configuration parameter.  Parameter: %0' 
+      return null;
+  end get_archive_location;
+
+  procedure archive_to_database
+  ( p_process_id        in flow_processes.prcs_id%type
+  , p_archive           in blob
+  , p_archive_location  in t_archive_location
+  )
+  is
+    l_insert_sql           varchar2(4000);
+    l_update_sql           varchar2(4000);
+    e_db_archive_fail      exception;
+
+  begin
+    apex_debug.enter ( 'archive_to_database',
+    'instance', p_process_id
+    );   
+
+    l_insert_sql := 'insert into '
+                    ||p_archive_location.db_table_name
+                    ||' ( ' ||p_archive_location.db_id_column 
+                    ||' , ' ||p_archive_location.db_blob_column
+                    ||' ) values ( :1, :2 )'
+                    ;
+    execute immediate l_insert_sql using p_process_id, p_archive;
+    apex_debug.message 
+    ( p_message => '-- Instance %0 inserted into archive to %1.%2'
+    , p0 => p_process_id
+    , p1 => p_archive_location.db_table_name
+    , p2 => p_archive_location.db_blob_column
+    ); 
+  exception
+    when dup_val_on_index then 
+      -- handle re-archive if the archive already exists.   This usually occurs if the process 
+      -- was reset after archiving.
+      l_update_sql := 'update '
+                      ||p_archive_location.db_table_name
+                      ||' set '
+                      ||p_archive_location.db_blob_column
+                      ||' = :1 where '
+                      ||p_archive_location.db_id_column
+                      ||' = :2 '
+                      ;
+      execute immediate l_update_sql using p_archive, p_process_id;
+      apex_debug.message 
+      ( p_message => '-- Instance %0 archive updated in %1.%2'
+      , p0 => p_process_id
+      , p1 => p_archive_location.db_table_name
+      , p2 => p_archive_location.db_blob_column
+      );
+    when others then
+      apex_debug.message 
+      ( p_message => 'Archiving instance %0 into database column %1.%2 failed. Failed SQL: %3.'
+      , p0 => p_process_id
+      , p1 => p_archive_location.db_table_name
+      , p2 => p_archive_location.db_blob_column
+      , p3 => l_insert_sql
+      ); 
+      raise e_db_archive_fail;
+  end archive_to_database;
+
+  procedure archive_to_oci
+  ( p_process_id        in flow_processes.prcs_id%type
+  , p_archive           in blob
+  , p_archive_location  in t_archive_location
+  )
+  is
+    l_url                       varchar2(4000);
+    l_response                  clob;
+    e_upload_failed_exception   exception;
+  begin
+    l_url := p_archive_location.oci_request_url
+              ||p_archive_location.oci_document_prefix
+              ||trim(to_char(p_process_id,'09999999'))||'.json';
+    apex_debug.message 
+    ( p_message => 'Preparing Archive URL - URL : %0 Credential Static ID: %1'
+    , p0 => l_url
+    , p1 => p_archive_location.oci_credential_static_id
+    );
+    apex_web_service.g_request_headers(1).name :=  'Content-Type';
+    apex_web_service.g_request_headers(1).value :=  'application/json';
+    l_response :=  apex_web_service.make_rest_request
+                   ( p_url          => l_url
+                   , p_http_method  => 'PUT'
+                   , p_body_blob    => p_archive
+                   , p_credential_static_id => p_archive_location.oci_credential_static_id
+                   );
+    if apex_web_service.g_status_code != 200 then
+      raise e_upload_failed_exception;
+    end if;
+  end archive_to_oci;
+
+  procedure archive_instance
+  ( p_process_id         flow_processes.prcs_id%type
+  , p_archive_location   t_archive_location
+  )
+  is
+    l_archive_blob   blob;
+  begin
+    -- create instance summary json
+    l_archive_blob := apex_util.clob_to_blob(p_clob  => get_instance_json_summary (p_process_id => p_process_id) );
+    -- store in preferred location
+    case p_archive_location.destination_type
+    when flow_constants_pkg.gc_config_archive_destination_table then
+      archive_to_database ( p_process_id       => p_process_id
+                          , p_archive          => l_archive_blob
+                          , p_archive_location => p_archive_location
+                          );
+    when flow_constants_pkg.gc_config_archive_destination_oci_api then
+      archive_to_oci      ( p_process_id       => p_process_id
+                          , p_archive          => l_archive_blob
+                          , p_archive_location => p_archive_location
+                          );   
+    when flow_constants_pkg.gc_config_archive_destination_oci_preauth then
+      archive_to_oci      ( p_process_id       => p_process_id
+                          , p_archive          => l_archive_blob
+                          , p_archive_location => p_archive_location
+                          );  
+    end case;
+    -- update instance with archive timestamp
+    update flow_processes
+    set prcs_archived_ts = systimestamp
+      , prcs_last_update = systimestamp
+    where prcs_id = p_process_id;
+  end archive_instance;
+
+  procedure archive_completed_instances
+  ( p_completed_before         in date default trunc(sysdate)
+  , p_process_id               in flow_processes.prcs_id%type default null  
+  )
+  is
+    type t_instance           is record (
+      prcs_id                 flow_processes.prcs_id%type);
+    type t_instances          is table of t_instance;
+
+    l_response                clob;
+    l_archive_location        t_archive_location;
+    l_instances               t_instances;
+
+    e_upload_failed_exception exception;
+  begin
+    apex_debug.enter ('archive_completed_instances'
+    ,'p_completed_before',p_completed_before
+    , 'p_process_id', p_process_id
+    );
+    -- get list of process instances to archive, if a single p_process_id was not passed in.
+    -- get all completed ('completed' or 'terminated') non-archived instances
+    if p_process_id is null then
+      select prcs.prcs_id
+        bulk collect into l_instances
+        from flow_processes prcs
+       where prcs.prcs_status in ( flow_constants_pkg.gc_prcs_status_completed
+                                 , flow_constants_pkg.gc_prcs_status_terminated )
+         and trunc(prcs.prcs_complete_ts) < p_completed_before
+         and prcs.prcs_archived_ts is null
+      ;
+    else
+      select p_process_id
+        bulk collect into l_instances
+        from dual;
+    end if;
+
+    apex_debug.message (p_message => 'Instances to be Archived : %0'
+    , p0 => l_instances.count);
+
+    if l_instances.count > 0 then
+      -- get archive location
+      l_archive_location := get_archive_location;
+      -- loop over instances
+      for instance in 1 .. l_instances.count
+      loop
+        -- lock flow_processes?
+        archive_instance ( p_process_id => l_instances(instance).prcs_id
+                         , p_archive_location => l_archive_location
+                         );
+        -- commit?
+      end loop;      
+    end if;
+  exception  
+    when others then
+      flow_errors.handle_general_error( pi_message_key  => 'log-archive-error'
+                                      , p0 => apex_web_service.g_status_code);
+      raise;      
+  end archive_completed_instances;
+
+end flow_log_admin;
+/

--- a/src/plsql/flow_log_admin.pks
+++ b/src/plsql/flow_log_admin.pks
@@ -1,0 +1,41 @@
+create or replace package flow_log_admin 
+  /* 
+  -- Flows for APEX - flow_log_admin.pks
+  -- 
+  -- (c) Copyright Oracle Corporation and / or its affiliates, 2023.
+
+  --
+  -- Created    18-Feb-2021  Richard Allen (Oracle)
+  --
+  -- Package flow_log_admin manaes the Flows for APEX log tables, including
+  --    - creation of instance archive summary
+  --    - archiving of instance logs
+  --    - purging of instance log tables 
+  */  
+  authid definer
+  accessible by ( flow_admin_api, flow_instances )
+  as
+
+  function get_instance_json_summary
+  ( p_process_id        in flow_processes.prcs_id%type
+  ) return clob;
+
+  -- archive_completed_instances is normally called by apex_automations after midnight
+  -- each day to prepare archive summaries for all processes that completed or terminated during
+  -- the previous day.  This can be done without specifying any parameters.
+  --
+  -- p_process_id should only be specified when you need to archive a specific process.  
+  -- Use Case for this is if a process instance is deleted (flow_api_pkg.flow_delete), archiving is enabled
+  -- and the instance has not yet been archived. Call archive_completed_instances specifying the process ID.
+
+  procedure archive_completed_instances
+  ( p_completed_before         in date default trunc(sysdate)
+  , p_process_id               in flow_processes.prcs_id%type default null  
+  );
+
+  procedure purge_instance_logs
+  ( p_retention_period_days  in number default null
+  );
+
+end flow_log_admin;
+/

--- a/src/plsql/flow_logging.pkb
+++ b/src/plsql/flow_logging.pkb
@@ -1,15 +1,14 @@
+create or replace package body flow_logging as
 /* 
 -- Flows for APEX - flow_logging.pkb
 -- 
 -- (c) Copyright Oracle Corporation and / or its affiliates, 2022-2023.
 -- (c) Copyright MT AG, 2021-2022.
 --
--- Created 29-Jul-2021  Richard Allen (Flowquest) for  MT AG  
+-- Created 29-Jul-2021  Richard Allen (Flowquest) for  MT AG
+-- updated 10-Feb-2023  Richard Allen (Oracle)  
 --
 */
-create or replace package body flow_logging
-as
-
   g_logging_level           flow_configuration.cfig_value%type; 
   g_logging_hide_userid     flow_configuration.cfig_value%type;
 

--- a/src/plsql/flow_logging.pkb
+++ b/src/plsql/flow_logging.pkb
@@ -1,7 +1,7 @@
 /* 
 -- Flows for APEX - flow_logging.pkb
 -- 
--- (c) Copyright Oracle Corporation and / or its affiliates, 2022.
+-- (c) Copyright Oracle Corporation and / or its affiliates, 2022-2023.
 -- (c) Copyright MT AG, 2021-2022.
 --
 -- Created 29-Jul-2021  Richard Allen (Flowquest) for  MT AG  
@@ -34,7 +34,8 @@ as
       , lgpr_prcs_name 
       , lgpr_business_id
       , lgpr_prcs_event
-      , lgpr_timestamp 
+      , lgpr_timestamp
+      , lgpr_duration 
       , lgpr_user 
       , lgpr_comment
       , lgpr_error_info
@@ -46,6 +47,14 @@ as
           , flow_proc_vars_int.get_business_ref (p_process_id)  --- 
           , p_event
           , systimestamp 
+          , case p_event
+            when flow_constants_pkg.gc_prcs_event_completed then
+              prcs.prcs_complete_ts - prcs.prcs_start_ts
+            when flow_constants_pkg.gc_prcs_event_terminated then
+              prcs.prcs_complete_ts - prcs.prcs_start_ts
+            else
+              null
+            end
           , case g_logging_hide_userid 
             when 'true' then 
               null

--- a/src/plsql/flow_logging.pks
+++ b/src/plsql/flow_logging.pks
@@ -44,5 +44,7 @@ as
   , p_var_tstz          in flow_process_variables.prov_var_tstz%type default null
   );
 
+  procedure purge_logs;
+
 end flow_logging;
 /

--- a/src/plsql/flow_logging.pks
+++ b/src/plsql/flow_logging.pks
@@ -1,13 +1,14 @@
+create or replace package flow_logging
 /* 
 -- Flows for APEX - flow_logging.pks
 -- 
--- (c) Copyright Oracle Corporation and / or its affiliates, 2022.
+-- (c) Copyright Oracle Corporation and / or its affiliates, 2022-2023.
 -- (c) Copyright MT AG, 2021-2022.
 --
 -- Created 29-Jul-2021  Richard Allen (Flowquest) for  MT AG  
+-- Updated 10-Feb-2023  Richard Allen, Oracle
 --
 */
-create or replace package flow_logging
   authid definer
   accessible by ( flow_engine, flow_instances, flow_proc_vars_int, flow_expressions 
                 , flow_boundary_events, flow_gateways, flow_tasks, flow_errors, flow_timers_pkg
@@ -43,8 +44,6 @@ as
   , p_var_clob          in flow_process_variables.prov_var_clob%type default null
   , p_var_tstz          in flow_process_variables.prov_var_tstz%type default null
   );
-
-  procedure purge_logs;
 
 end flow_logging;
 /

--- a/src/plsql/flow_settings.pkb
+++ b/src/plsql/flow_settings.pkb
@@ -3,7 +3,7 @@ as
 /* 
 -- Flows for APEX - flow_settings.pkb
 -- 
--- (c) Copyright Oracle Corporation and / or its affiliates, 2022.
+-- (c) Copyright Oracle Corporation and / or its affiliates, 2022-2023.
 --
 -- Created    23-Nov-2022  Richard Allen (Oracle)
 --

--- a/src/plsql/flow_statistics.pkb
+++ b/src/plsql/flow_statistics.pkb
@@ -770,17 +770,17 @@ union all
     apex_debug.enter(p_routine_name  => 'purge_statistics');
 
     l_daily_summary_purge_date      := sysdate - flow_engine_util.get_config_value
-                                      ( p_config_key => flow_constants_pkg.gc_config_log_retain_summary_daily 
-                                      , p_default_value => flow_constants_pkg.gc_config_default_log_retain_summary_daily   
+                                      ( p_config_key => flow_constants_pkg.gc_config_stats_retain_summary_daily 
+                                      , p_default_value => flow_constants_pkg.gc_config_default_stats_retain_summary_daily   
                                       );
     l_monthly_summary_purge_date    := add_months ( sysdate, -1 * flow_engine_util.get_config_value
-                                                      ( p_config_key => flow_constants_pkg.gc_config_log_retain_summary_month 
-                                                      , p_default_value => flow_constants_pkg.gc_config_default_log_retain_summary_month  
+                                                      ( p_config_key => flow_constants_pkg.gc_config_stats_retain_summary_month 
+                                                      , p_default_value => flow_constants_pkg.gc_config_default_stats_retain_summary_month  
                                                       )
                                                   );                                      
     l_quarterly_summary_purge_date  := add_months ( sysdate, -1 * flow_engine_util.get_config_value
-                                                      ( p_config_key => flow_constants_pkg.gc_config_log_retain_summary_qtr 
-                                                      , p_default_value => flow_constants_pkg.gc_config_default_log_retain_summary_qtr  
+                                                      ( p_config_key => flow_constants_pkg.gc_config_stats_retain_summary_qtr 
+                                                      , p_default_value => flow_constants_pkg.gc_config_default_stats_retain_summary_qtr  
                                                       )
                                                   );
 

--- a/src/plsql/flow_statistics.pkb
+++ b/src/plsql/flow_statistics.pkb
@@ -9,89 +9,187 @@ as
 --
 */
 
-procedure collect_step_statistics
+
 
 
 ------------------
 ---  collect daily step stats
 -------------------
-
-insert into flow_step_stats 
-        ( stsf_dgrm_id
-        , stsf_tag_name
-        , stsf_objt_bpmn_id
-        , stsf_period_start
-        , stsf_period
-        , stsf_duration_10pc_ivl
-        , stsf_duration_50pc_ivl
-        , stsf_duration_90pc_ivl
-        , stsf_duration_max_ivl
-        , stsf_duration_10pc_sec
-        , stsf_duration_50pc_sec
-        , stsf_duration_90pc_sec
-        , stsf_duration_max_sec
-        , stsf_waiting_10pc_ivl
-        , stsf_waiting_50pc_ivl
-        , stsf_waiting_90pc_ivl
-        , stsf_waiting_max_ivl
-        , stsf_waiting_10pc_sec
-        , stsf_waiting_50pc_sec
-        , stsf_waiting_90pc_sec
-        , stsf_waiting_max_sec  
-        , stsf_completed
-        ) 
-with ivl_stats as
-  ( select  lgsf_sbfl_dgrm_id                                                   as dgrm_id
-            , objt.objt_tag_name                                                as objt_tag_name
-            , lgsf_objt_id                                                      as objt_bpmn_id
-            , trunc (sys_extract_utc ( lgsf_completed ))                        as period_start
-            , approx_percentile (0.10 )
-                within group (order by (lgsf_completed - lgsf_was_current) ASC) as duration_10pc_ivl
-            , approx_percentile (0.50 )
-                within group (order by lgsf_completed - lgsf_was_current ASC)   as duration_50pc_ivl
-            , approx_percentile (0.90 )
-                within group (order by lgsf_completed - lgsf_was_current ASC)   as duration_90pc_ivl
-            , max ( lgsf_completed - lgsf_was_current)                          as duration_max_ivl
-            , approx_percentile (0.10 )
-                within group (order by (lgsf_started - lgsf_was_current) ASC)   as waiting_10pc_ivl
-            , approx_percentile (0.50 )
-                within group (order by lgsf_started - lgsf_was_current ASC)     as waiting_50pc_ivl
-            , approx_percentile (0.90 )
-                within group (order by lgsf_started - lgsf_was_current ASC)     as waiting_90pc_ivl
-            , max ( lgsf_started - lgsf_was_current)                            as waiting_max_ivl
-            , count (*)                                                         as completed
-       from flow_step_event_log lgsf
-  left join flow_objects objt
-         on objt.objt_dgrm_id = lgsf.lgsf_sbfl_dgrm_id
-        and objt.objt_bpmn_id = lgsf.lgsf_objt_id
-      where objt.objt_tag_name in ( 'bpmn:userTask', 'bpmn:serviceTask', 'bpmn:manualTask'
-                                  , 'bpmn:subProcess', 'bpmn:callActivity', 'bpmn:scriptTask', 'bpmn:task')
-   group by lgsf_sbfl_dgrm_id, objt.objt_tag_name, lgsf_objt_id, trunc (sys_extract_utc ( lgsf_completed ))
+  procedure create_daily_step_summary
+  ( p_start_date   in   date
   )
-select i.dgrm_id, i.objt_tag_name, i.objt_bpmn_id, i.period_start, 'DAY'
-     , i.duration_10pc_ivl
-     , i.duration_50pc_ivl
-     , i.duration_90pc_ivl
-     , i.duration_max_ivl
-     , flow_api_pkg.intervaldstosec (p_intervalds  => i.duration_10pc_ivl)
-     , flow_api_pkg.intervaldstosec (p_intervalds  => i.duration_50pc_ivl)
-     , flow_api_pkg.intervaldstosec (p_intervalds  => i.duration_90pc_ivl)
-     , flow_api_pkg.intervaldstosec (p_intervalds  => i.duration_max_ivl)
-     , i.waiting_10pc_ivl
-     , i.waiting_50pc_ivl
-     , i.waiting_90pc_ivl
-     , i.waiting_max_ivl
-     , flow_api_pkg.intervaldstosec (p_intervalds  => i.waiting_10pc_ivl)
-     , flow_api_pkg.intervaldstosec (p_intervalds  => i.waiting_50pc_ivl)
-     , flow_api_pkg.intervaldstosec (p_intervalds  => i.waiting_90pc_ivl)
-     , flow_api_pkg.intervaldstosec (p_intervalds  => i.waiting_max_ivl) 
-     , i.completed 
-from ivl_stats i
-;
+  is
+  begin
+      insert into flow_step_stats 
+          ( stsf_dgrm_id
+          , stsf_tag_name
+          , stsf_objt_bpmn_id
+          , stsf_period_start
+          , stsf_period
+          , stsf_duration_10pc_ivl
+          , stsf_duration_50pc_ivl
+          , stsf_duration_90pc_ivl
+          , stsf_duration_max_ivl
+          , stsf_duration_10pc_sec
+          , stsf_duration_50pc_sec
+          , stsf_duration_90pc_sec
+          , stsf_duration_max_sec
+          , stsf_waiting_10pc_ivl
+          , stsf_waiting_50pc_ivl
+          , stsf_waiting_90pc_ivl
+          , stsf_waiting_max_ivl
+          , stsf_waiting_10pc_sec
+          , stsf_waiting_50pc_sec
+          , stsf_waiting_90pc_sec
+          , stsf_waiting_max_sec  
+          , stsf_completed
+          ) 
+      with ivl_stats as
+        ( select  lgsf_sbfl_dgrm_id                                                   as dgrm_id
+                  , objt.objt_tag_name                                                as objt_tag_name
+                  , lgsf_objt_id                                                      as objt_bpmn_id
+                  , trunc (sys_extract_utc ( lgsf_completed ))                        as period_start
+                  , approx_percentile (0.10 )
+                      within group (order by (lgsf_completed - lgsf_was_current) ASC) as duration_10pc_ivl
+                  , approx_percentile (0.50 )
+                      within group (order by lgsf_completed - lgsf_was_current ASC)   as duration_50pc_ivl
+                  , approx_percentile (0.90 )
+                      within group (order by lgsf_completed - lgsf_was_current ASC)   as duration_90pc_ivl
+                  , max ( lgsf_completed - lgsf_was_current)                          as duration_max_ivl
+                  , approx_percentile (0.10 )
+                      within group (order by (lgsf_started - lgsf_was_current) ASC)   as waiting_10pc_ivl
+                  , approx_percentile (0.50 )
+                      within group (order by lgsf_started - lgsf_was_current ASC)     as waiting_50pc_ivl
+                  , approx_percentile (0.90 )
+                      within group (order by lgsf_started - lgsf_was_current ASC)     as waiting_90pc_ivl
+                  , max ( lgsf_started - lgsf_was_current)                            as waiting_max_ivl
+                  , count (*)                                                         as completed
+             from flow_step_event_log lgsf
+        left join flow_objects objt
+               on objt.objt_dgrm_id = lgsf.lgsf_sbfl_dgrm_id
+              and objt.objt_bpmn_id = lgsf.lgsf_objt_id
+            where objt.objt_tag_name in ( 'bpmn:userTask', 'bpmn:serviceTask', 'bpmn:manualTask'
+                                        , 'bpmn:subProcess', 'bpmn:callActivity', 'bpmn:scriptTask', 'bpmn:task')
+         group by lgsf_sbfl_dgrm_id, objt.objt_tag_name, lgsf_objt_id, trunc (sys_extract_utc ( lgsf_completed ))
+        )
+      select i.dgrm_id
+           , i.objt_tag_name
+           , i.objt_bpmn_id
+           , i.period_start
+           , flow_constants_pkg.gc_stats_period_day 
+           , i.duration_10pc_ivl
+           , i.duration_50pc_ivl
+           , i.duration_90pc_ivl
+           , i.duration_max_ivl
+           , flow_api_pkg.intervaldstosec (p_intervalds  => i.duration_10pc_ivl)
+           , flow_api_pkg.intervaldstosec (p_intervalds  => i.duration_50pc_ivl)
+           , flow_api_pkg.intervaldstosec (p_intervalds  => i.duration_90pc_ivl)
+           , flow_api_pkg.intervaldstosec (p_intervalds  => i.duration_max_ivl)
+           , i.waiting_10pc_ivl
+           , i.waiting_50pc_ivl
+           , i.waiting_90pc_ivl
+           , i.waiting_max_ivl
+           , flow_api_pkg.intervaldstosec (p_intervalds  => i.waiting_10pc_ivl)
+           , flow_api_pkg.intervaldstosec (p_intervalds  => i.waiting_50pc_ivl)
+           , flow_api_pkg.intervaldstosec (p_intervalds  => i.waiting_90pc_ivl)
+           , flow_api_pkg.intervaldstosec (p_intervalds  => i.waiting_max_ivl) 
+           , i.completed 
+      from ivl_stats i
+      where i.period_start between p_start_date and trunc(sysdate)-1
+      ;
+  end create_daily_step_summary;
+  
+  
+  procedure create_monthly_step_summaries
+  ( p_start_date in date
+  )
+  is
+  begin
+    -- delete existing MTD summaries
+    -- delete and recreate, rather than update,  because not all instances might have a MTD summary for this month yet
+    delete from flow_step_stats
+     where stsf_period = 'MTD';
+    -- now create 'MONTH' summaries for any month that doesn't yet exist and MTD to current month
+    insert into flow_step_stats 
+            ( stsf_dgrm_id
+            , stsf_tag_name
+            , stsf_objt_bpmn_id
+            , stsf_period_start
+            , stsf_period
+            , stsf_duration_10pc_ivl
+            , stsf_duration_50pc_ivl
+            , stsf_duration_90pc_ivl
+            , stsf_duration_max_ivl
+            , stsf_duration_10pc_sec
+            , stsf_duration_50pc_sec
+            , stsf_duration_90pc_sec
+            , stsf_duration_max_sec
+            , stsf_waiting_10pc_ivl
+            , stsf_waiting_50pc_ivl
+            , stsf_waiting_90pc_ivl
+            , stsf_waiting_max_ivl
+            , stsf_waiting_10pc_sec
+            , stsf_waiting_50pc_sec
+            , stsf_waiting_90pc_sec
+            , stsf_waiting_max_sec  
+            , stsf_completed
+            )
+    with mon as 
+    (
+      select stsf_dgrm_id, 
+             stsf_tag_name,
+             stsf_objt_bpmn_id,
+             trunc(stsf_period_start, 'MM') period_start, 
+             sum ( ds.stsf_duration_10pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_10pc_sec,
+             sum ( ds.stsf_duration_50pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_50pc_sec, 
+             sum ( ds.stsf_duration_90pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_90pc_sec, 
+             sum ( ds.stsf_duration_max_sec  * ds.stsf_completed ) / sum (ds.stsf_completed) duration_max_sec,
+             sum ( ds.stsf_waiting_10pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_10pc_sec,
+             sum ( ds.stsf_waiting_50pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_50pc_sec, 
+             sum ( ds.stsf_waiting_90pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_90pc_sec, 
+             sum ( ds.stsf_waiting_max_sec  * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_max_sec,
+             sum ( stsf_completed) stsf_completed
+      from   flow_step_stats ds
+      where  ds.stsf_period = 'DAY'
+      group by stsf_dgrm_id, stsf_tag_name, stsf_objt_bpmn_id, trunc(stsf_period_start, 'MM')
+      order by stsf_dgrm_id, stsf_tag_name, stsf_objt_bpmn_id, trunc(stsf_period_start, 'MM')
+    )
+    select mon.stsf_dgrm_id
+         , mon.stsf_tag_name
+         , mon.stsf_objt_bpmn_id
+         , mon.period_start
+         , case when mon.period_start = trunc(sys_extract_utc(systimestamp),'MM') then 'MTD'
+                else 'MONTH' end as period
+         , numtodsinterval (mon.duration_10pc_sec , 'SECOND') as duration_10pc_ivl
+         , numtodsinterval (mon.duration_50pc_sec , 'SECOND') as duration_50pc_ivl
+         , numtodsinterval (mon.duration_90pc_sec , 'SECOND') as duration_90pc_ivl
+         , numtodsinterval (mon.duration_max_sec  , 'SECOND') as duration_max_ivl
+         , mon.duration_10pc_sec
+         , mon.duration_50pc_sec
+         , mon.duration_90pc_sec
+         , mon.duration_max_sec
+         , numtodsinterval (mon.waiting_10pc_sec , 'SECOND') as waiting_10pc_ivl
+         , numtodsinterval (mon.waiting_50pc_sec , 'SECOND') as waiting_50pc_ivl
+         , numtodsinterval (mon.waiting_90pc_sec , 'SECOND') as waiting_90pc_ivl
+         , numtodsinterval (mon.waiting_max_sec  , 'SECOND') as waiting_max_ivl
+         , mon.waiting_10pc_sec
+         , mon.waiting_50pc_sec
+         , mon.waiting_90pc_sec
+         , mon.waiting_max_sec
+         , mon.stsf_completed
+    from mon
+    where mon.period_start >= trunc(p_start_date,'MM');
+  
+  end create_monthly_step_summaries; 
 
--- monthly step stats
+  -- quarter step stats
 
-insert into flow_step_stats 
+  procedure create_quarterly_step_summaries  
+  ( p_start_date   in date
+  )
+  is
+  begin
+    insert into flow_step_stats 
         ( stsf_dgrm_id
         , stsf_tag_name
         , stsf_objt_bpmn_id
@@ -115,358 +213,276 @@ insert into flow_step_stats
         , stsf_waiting_max_sec  
         , stsf_completed
         )
-with mon as 
-(
-select stsf_dgrm_id, 
-       stsf_tag_name,
-       stsf_objt_bpmn_id,
-       trunc(stsf_period_start, 'MM') period_start, 
-       sum ( ds.stsf_duration_10pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_10pc_sec,
-       sum ( ds.stsf_duration_50pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_50pc_sec, 
-       sum ( ds.stsf_duration_90pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_90pc_sec, 
-       sum ( ds.stsf_duration_max_sec  * ds.stsf_completed ) / sum (ds.stsf_completed) duration_max_sec,
-       sum ( ds.stsf_waiting_10pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_10pc_sec,
-       sum ( ds.stsf_waiting_50pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_50pc_sec, 
-       sum ( ds.stsf_waiting_90pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_90pc_sec, 
-       sum ( ds.stsf_waiting_max_sec  * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_max_sec,
-       sum ( stsf_completed) stsf_completed
-from   flow_step_stats ds
-where  ds.stsf_period = 'DAY'
-group by stsf_dgrm_id, stsf_tag_name, stsf_objt_bpmn_id, trunc(stsf_period_start, 'MM')
-order by stsf_dgrm_id, stsf_tag_name, stsf_objt_bpmn_id, trunc(stsf_period_start, 'MM')
-)
-select mon.stsf_dgrm_id
-     , mon.stsf_tag_name
-     , mon.stsf_objt_bpmn_id
-     , mon.period_start
-     , 'MONTH' as period
-     , numtodsinterval (mon.duration_10pc_sec , 'SECOND') as duration_10pc_ivl
-     , numtodsinterval (mon.duration_50pc_sec , 'SECOND') as duration_50pc_ivl
-     , numtodsinterval (mon.duration_90pc_sec , 'SECOND') as duration_90pc_ivl
-     , numtodsinterval (mon.duration_max_sec  , 'SECOND') as duration_max_ivl
-     , mon.duration_10pc_sec
-     , mon.duration_50pc_sec
-     , mon.duration_90pc_sec
-     , mon.duration_max_sec
-     , numtodsinterval (mon.waiting_10pc_sec , 'SECOND') as waiting_10pc_ivl
-     , numtodsinterval (mon.waiting_50pc_sec , 'SECOND') as waiting_50pc_ivl
-     , numtodsinterval (mon.waiting_90pc_sec , 'SECOND') as waiting_90pc_ivl
-     , numtodsinterval (mon.waiting_max_sec  , 'SECOND') as waiting_max_ivl
-     , mon.waiting_10pc_sec
-     , mon.waiting_50pc_sec
-     , mon.waiting_90pc_sec
-     , mon.waiting_max_sec
-     , mon.stsf_completed
-from mon;
+    with mon as 
+    (
+    select stsf_dgrm_id, 
+           stsf_tag_name,
+           stsf_objt_bpmn_id,
+           trunc(stsf_period_start, 'Q') period_start, 
+           sum ( ds.stsf_duration_10pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_10pc_sec,
+           sum ( ds.stsf_duration_50pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_50pc_sec, 
+           sum ( ds.stsf_duration_90pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_90pc_sec, 
+           sum ( ds.stsf_duration_max_sec  * ds.stsf_completed ) / sum (ds.stsf_completed) duration_max_sec,
+           sum ( ds.stsf_waiting_10pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_10pc_sec,
+           sum ( ds.stsf_waiting_50pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_50pc_sec, 
+           sum ( ds.stsf_waiting_90pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_90pc_sec, 
+           sum ( ds.stsf_waiting_max_sec  * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_max_sec,
+           sum ( stsf_completed) stsf_completed
+     from  flow_step_stats ds
+    where  ds.stsf_period = 'MONTH'
+      and  ds.stsf_period_start >= p_start_date
+    group by stsf_dgrm_id, stsf_tag_name, stsf_objt_bpmn_id, trunc(stsf_period_start, 'Q')
+    order by stsf_dgrm_id, stsf_tag_name, stsf_objt_bpmn_id, trunc(stsf_period_start, 'Q')
+    )
+    select mon.stsf_dgrm_id
+         , mon.stsf_tag_name
+         , mon.stsf_objt_bpmn_id
+         , mon.period_start
+         , 'QUARTER' as period
+         , numtodsinterval (mon.duration_10pc_sec , 'SECOND') as duration_10pc_ivl
+         , numtodsinterval (mon.duration_50pc_sec , 'SECOND') as duration_50pc_ivl
+         , numtodsinterval (mon.duration_90pc_sec , 'SECOND') as duration_90pc_ivl
+         , numtodsinterval (mon.duration_max_sec  , 'SECOND') as duration_max_ivl
+         , mon.duration_10pc_sec
+         , mon.duration_50pc_sec
+         , mon.duration_90pc_sec
+         , mon.duration_max_sec
+         , numtodsinterval (mon.waiting_10pc_sec , 'SECOND') as waiting_10pc_ivl
+         , numtodsinterval (mon.waiting_50pc_sec , 'SECOND') as waiting_50pc_ivl
+         , numtodsinterval (mon.waiting_90pc_sec , 'SECOND') as waiting_90pc_ivl
+         , numtodsinterval (mon.waiting_max_sec  , 'SECOND') as waiting_max_ivl
+         , mon.waiting_10pc_sec
+         , mon.waiting_50pc_sec
+         , mon.waiting_90pc_sec
+         , mon.waiting_max_sec
+         , mon.stsf_completed
+    from mon
+    where mon.period_start between p_start_date and add_months ( trunc( sys_extract_utc (systimestamp), 'Q' ), -3)
+    ;
+  end create_quarterly_step_summaries;
 
--- quarter step stats
-
-insert into flow_step_stats 
-        ( stsf_dgrm_id
-        , stsf_tag_name
-        , stsf_objt_bpmn_id
-        , stsf_period_start
-        , stsf_period
-        , stsf_duration_10pc_ivl
-        , stsf_duration_50pc_ivl
-        , stsf_duration_90pc_ivl
-        , stsf_duration_max_ivl
-        , stsf_duration_10pc_sec
-        , stsf_duration_50pc_sec
-        , stsf_duration_90pc_sec
-        , stsf_duration_max_sec
-        , stsf_waiting_10pc_ivl
-        , stsf_waiting_50pc_ivl
-        , stsf_waiting_90pc_ivl
-        , stsf_waiting_max_ivl
-        , stsf_waiting_10pc_sec
-        , stsf_waiting_50pc_sec
-        , stsf_waiting_90pc_sec
-        , stsf_waiting_max_sec  
-        , stsf_completed
+  ------------------
+  ---  collect daily process stats
+  -------------------
+  procedure create_daily_instance_summary
+  ( p_start_date   in   date
+  )
+  is
+  begin
+    insert into flow_instance_stats
+        ( stpr_dgrm_id    
+        , stpr_period_start  
+        , stpr_period
+        , stpr_created    
+        , stpr_started    
+        , stpr_error      
+        , stpr_completed  
+        , stpr_terminated 
+        , stpr_reset      
+        , stpr_duration_10pc_ivl
+        , stpr_duration_50pc_ivl
+        , stpr_duration_90pc_ivl
+        , stpr_duration_max_ivl 
+        , stpr_duration_10pc_sec
+        , stpr_duration_50pc_sec
+        , stpr_duration_90pc_sec
+        , stpr_duration_max_sec 
         )
-with mon as 
-(
-select stsf_dgrm_id, 
-       stsf_tag_name,
-       stsf_objt_bpmn_id,
-       trunc(stsf_period_start, 'Q') period_start, 
-       sum ( ds.stsf_duration_10pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_10pc_sec,
-       sum ( ds.stsf_duration_50pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_50pc_sec, 
-       sum ( ds.stsf_duration_90pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_90pc_sec, 
-       sum ( ds.stsf_duration_max_sec  * ds.stsf_completed ) / sum (ds.stsf_completed) duration_max_sec,
-       sum ( ds.stsf_waiting_10pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_10pc_sec,
-       sum ( ds.stsf_waiting_50pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_50pc_sec, 
-       sum ( ds.stsf_waiting_90pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_90pc_sec, 
-       sum ( ds.stsf_waiting_max_sec  * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_max_sec,
-       sum ( stsf_completed) stsf_completed
-from   flow_step_stats ds
-where  ds.stsf_period = 'MONTH'
-group by stsf_dgrm_id, stsf_tag_name, stsf_objt_bpmn_id, trunc(stsf_period_start, 'Q')
-order by stsf_dgrm_id, stsf_tag_name, stsf_objt_bpmn_id, trunc(stsf_period_start, 'Q')
-)
-select mon.stsf_dgrm_id
-     , mon.stsf_tag_name
-     , mon.stsf_objt_bpmn_id
-     , mon.period_start
-     , 'QUARTER' as period
-     , numtodsinterval (mon.duration_10pc_sec , 'SECOND') as duration_10pc_ivl
-     , numtodsinterval (mon.duration_50pc_sec , 'SECOND') as duration_50pc_ivl
-     , numtodsinterval (mon.duration_90pc_sec , 'SECOND') as duration_90pc_ivl
-     , numtodsinterval (mon.duration_max_sec  , 'SECOND') as duration_max_ivl
-     , mon.duration_10pc_sec
-     , mon.duration_50pc_sec
-     , mon.duration_90pc_sec
-     , mon.duration_max_sec
-     , numtodsinterval (mon.waiting_10pc_sec , 'SECOND') as waiting_10pc_ivl
-     , numtodsinterval (mon.waiting_50pc_sec , 'SECOND') as waiting_50pc_ivl
-     , numtodsinterval (mon.waiting_90pc_sec , 'SECOND') as waiting_90pc_ivl
-     , numtodsinterval (mon.waiting_max_sec  , 'SECOND') as waiting_max_ivl
-     , mon.waiting_10pc_sec
-     , mon.waiting_50pc_sec
-     , mon.waiting_90pc_sec
-     , mon.waiting_max_sec
-     , mon.stsf_completed
-from mon;
+    with daily_event_completion_times as
+        (   select lgpr_dgrm_id dgrm_id
+                 , trunc (sys_extract_utc (lgpr_timestamp )) period_start
+                 , lgpr_prcs_event event
+                 , count (*) times
+                 , approx_percentile (0.10 )
+                        within group (order by (lgpr_duration) ASC) duration_10pc_ivl
+                 , approx_percentile (0.50 )
+                        within group (order by (lgpr_duration) ASC) duration_50pc_ivl
+                 , approx_percentile (0.90 )
+                        within group (order by (lgpr_duration) ASC) duration_90pc_ivl
+                 , max (lgpr_duration) duration_Max_ivl
+            from flow_instance_event_log lgpr
+            where lgpr.lgpr_prcs_event in ('created','started', 'error', 'completed', 'terminated', 'reset')
+            group by lgpr_dgrm_id
+                   , trunc (sys_extract_utc (lgpr_timestamp )) 
+                   , lgpr_prcs_event
+            order by lgpr_dgrm_id
+                   , trunc (sys_extract_utc (lgpr_timestamp )) 
+                   , lgpr_prcs_event 
+        ),
+    prcs_pivot_totals as 
+        (    select * from 
+                (select dgrm_id, period_start, event, times 
+                from daily_event_completion_times
+                ) tot pivot (sum (times)
+                for event in ( 'created' as CREATED, 'started' as STARTED, 'error' as ERROR
+                             , 'completed' as COMPLETED, 'terminated' as TERMINATED, 'reset' as RESET))
+            order by dgrm_id  
+        )
+    select t.dgrm_id
+         , t.period_start
+         , flow_constants_pkg.gc_stats_period_day 
+         , p.created, p.started, p.error, p.completed, p.terminated, p.reset
+         , t.duration_10pc_ivl
+         , t.duration_50pc_ivl
+         , t.duration_90pc_ivl
+         , t.duration_Max_ivl
+         , flow_api_pkg.intervalDStoSec (t.duration_10pc_ivl) duration_10pc_sec
+         , flow_api_pkg.intervalDStoSec (t.duration_50pc_ivl) duration_50pc_sec
+         , flow_api_pkg.intervalDStoSec (t.duration_90pc_ivl) duration_90pc_sec
+         , flow_api_pkg.intervalDStoSec (t.duration_max_ivl ) duration_max_sec
+     from  prcs_pivot_totals p
+     join  daily_event_completion_times t
+       on  t.dgrm_id = p.dgrm_id
+      and  t.period_start = p.period_start
+    where  t.event = 'completed'
+      and  t.period_start between p_start_date and trunc(sysdate)-1
+    ;
+  end create_daily_instance_summary;
 
 
-------------------
----  collect daily process stats
--------------------
-insert into flow_instance_stats
-    ( stpr_dgrm_id    
-    , stpr_period_start  
-    , stpr_period
-    , stpr_created    
-    , stpr_started    
-    , stpr_error      
-    , stpr_completed  
-    , stpr_terminated 
-    , stpr_reset      
-    , stpr_duration_10pc_ivl
-    , stpr_duration_50pc_ivl
-    , stpr_duration_90pc_ivl
-    , stpr_duration_max_ivl 
-    , stpr_duration_10pc_sec
-    , stpr_duration_50pc_sec
-    , stpr_duration_90pc_sec
-    , stpr_duration_max_sec 
+  -- creeate monthly instance summaries
+  procedure create_monthly_instance_summaries
+  ( p_start_date in date
+  )
+  is
+  begin
+    -- delete existing MTD summaries
+    -- delete and recreate, rather than update,  because not all instances might have a MTD summary for this month yet
+    delete from flow_instance_stats
+     where stpr_period = 'MTD';
+    -- now create 'MONTH' summaries for any month that doesn't yet exist and MTD to current month
+    insert into flow_instance_stats
+        ( stpr_dgrm_id    
+        , stpr_period_start  
+        , stpr_period
+        , stpr_created    
+        , stpr_started    
+        , stpr_error      
+        , stpr_completed  
+        , stpr_terminated 
+        , stpr_reset      
+        , stpr_duration_10pc_ivl
+        , stpr_duration_50pc_ivl
+        , stpr_duration_90pc_ivl
+        , stpr_duration_max_ivl 
+        , stpr_duration_10pc_sec
+        , stpr_duration_50pc_sec
+        , stpr_duration_90pc_sec
+        , stpr_duration_max_sec 
+        )
+    with mon as 
+    (
+    select stpr_dgrm_id, 
+           trunc(stpr_period_start, 'MM') period_start, 
+           sum (stpr_created) stpr_created,
+           sum (stpr_started) stpr_started,
+           sum (stpr_error) stpr_error,
+           sum (stpr_completed) stpr_completed,
+           sum (stpr_terminated) stpr_terminated,
+           sum (stpr_reset) stpr_reset,
+           sum ( ds.stpr_duration_10pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_10pc_sec,
+           sum ( ds.stpr_duration_50pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_50pc_sec, 
+           sum ( ds.stpr_duration_90pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_90pc_sec, 
+           sum ( ds.stpr_duration_max_sec * ds.stpr_completed  ) / sum (ds.stpr_completed) duration_max_sec
+    from   flow_instance_stats ds
+    where  ds.stpr_period = 'DAY'
+    group by stpr_dgrm_id, trunc(stpr_period_start, 'MM')
+    order by stpr_dgrm_id, trunc(stpr_period_start, 'MM')
     )
-with prcs_daily_totals as
-    (   select lgpr_dgrm_id dgrm_id
-             , trunc (sys_extract_utc (lgpr_timestamp )) period_start
-             , lgpr_prcs_event event
-             , count (*) times
-             , approx_percentile (0.10 )
-                    within group (order by (lgpr_duration) ASC) duration_10pc_ivl
-             , approx_percentile (0.50 )
-                    within group (order by (lgpr_duration) ASC) duration_50pc_ivl
-             , approx_percentile (0.90 )
-                    within group (order by (lgpr_duration) ASC) duration_90pc_ivl
-             , max (lgpr_duration) duration_Max_ivl
-        from flow_instance_event_log lgpr
-        where lgpr.lgpr_prcs_event in ('created','started', 'error', 'completed', 'terminated', 'reset')
-        group by lgpr_dgrm_id
-               , trunc (sys_extract_utc (lgpr_timestamp )) 
-               , lgpr_prcs_event
-        order by lgpr_dgrm_id
-               , trunc (sys_extract_utc (lgpr_timestamp )) 
-               , lgpr_prcs_event 
-    ),
-prcs_pivot_totals as 
-    (    select * from 
-            (select dgrm_id, period_start, event, times 
-            from prcs_daily_totals
-            ) tot pivot (sum (times)
-            for event in ('created' as CREATED, 'started' as STARTED, 'error' as ERROR, 'completed' as COMPLETED, 'terminated' as TERMINATED, 'reset' as RESET))
-        order by dgrm_id  
+    select mon.stpr_dgrm_id
+         , mon.period_start
+         , case when mon.period_start = trunc(sys_extract_utc(systimestamp),'MM') then 'MTD'
+                else 'MONTH' end as period
+         , mon.stpr_created
+         , mon.stpr_started
+         , mon.stpr_error
+         , mon.stpr_completed
+         , mon.stpr_terminated
+         , mon.stpr_reset
+         , numtoDSinterval( mon.duration_10pc_sec, 'SECOND' )
+         , numtoDSinterval( mon.duration_50pc_sec, 'SECOND' )
+         , numtoDSinterval( mon.duration_90pc_sec, 'SECOND' )
+         , numtoDSinterval( mon.duration_max_sec , 'SECOND' )
+         , mon.duration_10pc_sec
+         , mon.duration_50pc_sec
+         , mon.duration_90pc_sec
+         , mon.duration_max_sec
+    from mon
+    where mon.period_start >= trunc(p_start_date,'MM');
+
+  end create_monthly_instance_summaries;
+
+  -- quarter summary
+
+  procedure create_quarterly_instance_summaries  
+  ( p_start_date   in date
+  )
+  is
+  begin
+
+    insert into flow_instance_stats
+      ( stpr_dgrm_id    
+      , stpr_period_start  
+      , stpr_period
+      , stpr_created    
+      , stpr_started    
+      , stpr_error      
+      , stpr_completed  
+      , stpr_terminated 
+      , stpr_reset      
+      , stpr_duration_10pc_ivl
+      , stpr_duration_50pc_ivl
+      , stpr_duration_90pc_ivl
+      , stpr_duration_max_ivl 
+      , stpr_duration_10pc_sec
+      , stpr_duration_50pc_sec
+      , stpr_duration_90pc_sec
+      , stpr_duration_max_sec 
+      )
+    with mon as 
+    (
+    select stpr_dgrm_id, 
+         trunc(stpr_period_start, 'Q') period_start, 
+         sum (stpr_created) stpr_created,
+         sum (stpr_started) stpr_started,
+         sum (stpr_error) stpr_error,
+         sum (stpr_completed) stpr_completed,
+         sum (stpr_terminated) stpr_terminated,
+         sum (stpr_reset) stpr_reset,
+         sum ( ds.stpr_duration_10pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_10pc_sec,
+         sum ( ds.stpr_duration_50pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_50pc_sec, 
+         sum ( ds.stpr_duration_90pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_90pc_sec, 
+         sum ( ds.stpr_duration_max_sec * ds.stpr_completed  ) / sum (ds.stpr_completed) duration_max_sec
+    from   flow_instance_stats ds
+    where  ds.stpr_period = 'MONTH'
+      and  ds.stpr_period_start >= p_start_date
+    group by stpr_dgrm_id, trunc(stpr_period_start, 'Q')
+    order by stpr_dgrm_id, trunc(stpr_period_start, 'Q')
     )
-select t.dgrm_id, t.period_start,  'DAY' 
-     , p.created, p.started, p.error, p.completed, p.terminated, p.reset
-     , t.duration_10pc_ivl
-     , t.duration_50pc_ivl
-     , t.duration_90pc_ivl
-     , t.duration_Max_ivl
-     , flow_api_pkg.intervalDStoSec (t.duration_10pc_ivl) duration_10pc_sec
-     , flow_api_pkg.intervalDStoSec (t.duration_50pc_ivl) duration_50pc_sec
-     , flow_api_pkg.intervalDStoSec (t.duration_90pc_ivl) duration_90pc_sec
-     , flow_api_pkg.intervalDStoSec (t.duration_max_ivl ) duration_max_sec
- from  prcs_pivot_totals p
- join  prcs_daily_totals t
-   on  t.dgrm_id = p.dgrm_id
-  and  t.period_start = p.period_start
-where  t.event = 'completed'
+    select mon.stpr_dgrm_id
+       , mon.period_start
+       , 'QUARTER' as period
+       , mon.stpr_created
+       , mon.stpr_started
+       , mon.stpr_error
+       , mon.stpr_completed
+       , mon.stpr_terminated
+       , mon.stpr_reset
+       , numtoDSinterval( mon.duration_10pc_sec, 'SECOND' )
+       , numtoDSinterval( mon.duration_50pc_sec, 'SECOND' )
+       , numtoDSinterval( mon.duration_90pc_sec, 'SECOND' )
+       , numtoDSinterval( mon.duration_max_sec , 'SECOND' )
+       , mon.duration_10pc_sec
+       , mon.duration_50pc_sec
+       , mon.duration_90pc_sec
+       , mon.duration_max_sec
+    from mon
+    where mon.period_start between p_start_date and add_months ( trunc( sys_extract_utc (systimestamp), 'Q' ), -3)
+    ;
 
--- alternate daily stats
-with prcs_daily_totals as
-    (   select lgpr_dgrm_id dgrm_id
-             , trunc (sys_extract_utc (sysdate )) period_start
-             , lgpr_prcs_event event
-             , count (*) times
-             , approx_percentile (0.10 )
-                    within group (order by (lgpr_duration) ASC) duration_10pc_ivl
-             , approx_percentile (0.50 )
-                    within group (order by (lgpr_duration) ASC) duration_50pc_ivl
-             , approx_percentile (0.90 )
-                    within group (order by (lgpr_duration) ASC) duration_90pc_ivl
-             , max (lgpr_duration) duration_Max_ivl
-             , sum ( case lgpr_prcs_event when 'created' then 1 else 0 end) num_created
-        from flow_instance_event_log lgpr
-        where lgpr.lgpr_prcs_event in ('created','started', 'error', 'completed', 'terminated', 'reset')
-        group by lgpr_dgrm_id
-               , trunc (sys_extract_utc (sysdate )) 
-               , lgpr_prcs_event
-        order by lgpr_dgrm_id
-               , trunc (sys_extract_utc (sysdate )) 
-               , lgpr_prcs_event 
-    ),
-prcs_pivot_totals as 
-    (    select * from 
-            (select dgrm_id, period_start, event, times 
-            from prcs_daily_totals
-            ) tot pivot (sum (times)
-            for event in ('created' as CREATED, 'started' as STARTED, 'error' as ERROR, 'completed' as COMPLETED, 'terminated' as TERMINATED, 'reset' as RESET))
-        order by dgrm_id  
-    )
-select t.dgrm_id, t.period_start,  'DAY' 
-     , p.created, p.started, p.error, p.completed, p.terminated, p.reset
-     , t.duration_10pc_ivl
-     , t.duration_50pc_ivl
-     , t.duration_90pc_ivl
-     , t.duration_Max_ivl
-     , flow_api_pkg.intervalDStoSec (t.duration_10pc_ivl) duration_10pc_sec
-     , flow_api_pkg.intervalDStoSec (t.duration_50pc_ivl) duration_50pc_sec
-     , flow_api_pkg.intervalDStoSec (t.duration_90pc_ivl) duration_90pc_sec
-     , flow_api_pkg.intervalDStoSec (t.duration_max_ivl ) duration_max_sec
- from  prcs_pivot_totals p
- join  prcs_daily_totals t
-   on  t.dgrm_id = p.dgrm_id
-  and  t.period_start = p.period_start
-where  t.event = 'completed'
+  end create_quarterly_instance_summaries;
 
-
--- creeate monthly instance summaries
-
-insert into flow_instance_stats
-    ( stpr_dgrm_id    
-    , stpr_period_start  
-    , stpr_period
-    , stpr_created    
-    , stpr_started    
-    , stpr_error      
-    , stpr_completed  
-    , stpr_terminated 
-    , stpr_reset      
-    , stpr_duration_10pc_ivl
-    , stpr_duration_50pc_ivl
-    , stpr_duration_90pc_ivl
-    , stpr_duration_max_ivl 
-    , stpr_duration_10pc_sec
-    , stpr_duration_50pc_sec
-    , stpr_duration_90pc_sec
-    , stpr_duration_max_sec 
-    )
-with mon as 
-(
-select stpr_dgrm_id, 
-       trunc(stpr_period_start, 'MM') period_start, 
-       sum (stpr_created) stpr_created,
-       sum (stpr_started) stpr_started,
-       sum (stpr_error) stpr_error,
-       sum (stpr_completed) stpr_completed,
-       sum (stpr_terminated) stpr_terminated,
-       sum (stpr_reset) stpr_reset,
-       sum ( ds.stpr_duration_10pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_10pc_sec,
-       sum ( ds.stpr_duration_50pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_50pc_sec, 
-       sum ( ds.stpr_duration_90pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_90pc_sec, 
-       sum ( ds.stpr_duration_max_sec * ds.stpr_completed  ) / sum (ds.stpr_completed) duration_max_sec
-from   flow_instance_stats ds
-where  ds.stpr_period = 'DAY'
-group by stpr_dgrm_id, trunc(stpr_period_start, 'MM')
-order by stpr_dgrm_id, trunc(stpr_period_start, 'MM')
-)
-select mon.stpr_dgrm_id
-     , mon.period_start
-     , 'MONTH' as period
-     , mon.stpr_created
-     , mon.stpr_started
-     , mon.stpr_error
-     , mon.stpr_completed
-     , mon.stpr_terminated
-     , mon.stpr_reset
-     , numtoDSinterval( mon.duration_10pc_sec, 'SECOND' )
-     , numtoDSinterval( mon.duration_50pc_sec, 'SECOND' )
-     , numtoDSinterval( mon.duration_90pc_sec, 'SECOND' )
-     , numtoDSinterval( mon.duration_max_sec , 'SECOND' )
-     , mon.duration_10pc_sec
-     , mon.duration_50pc_sec
-     , mon.duration_90pc_sec
-     , mon.duration_max_sec
-from mon
-
--- quarter summary
-
-insert into flow_instance_stats
-    ( stpr_dgrm_id    
-    , stpr_period_start  
-    , stpr_period
-    , stpr_created    
-    , stpr_started    
-    , stpr_error      
-    , stpr_completed  
-    , stpr_terminated 
-    , stpr_reset      
-    , stpr_duration_10pc_ivl
-    , stpr_duration_50pc_ivl
-    , stpr_duration_90pc_ivl
-    , stpr_duration_max_ivl 
-    , stpr_duration_10pc_sec
-    , stpr_duration_50pc_sec
-    , stpr_duration_90pc_sec
-    , stpr_duration_max_sec 
-    )
-with mon as 
-(
-select stpr_dgrm_id, 
-       trunc(stpr_period_start, 'Q') period_start, 
-       sum (stpr_created) stpr_created,
-       sum (stpr_started) stpr_started,
-       sum (stpr_error) stpr_error,
-       sum (stpr_completed) stpr_completed,
-       sum (stpr_terminated) stpr_terminated,
-       sum (stpr_reset) stpr_reset,
-       sum ( ds.stpr_duration_10pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_10pc_sec,
-       sum ( ds.stpr_duration_50pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_50pc_sec, 
-       sum ( ds.stpr_duration_90pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_90pc_sec, 
-       sum ( ds.stpr_duration_max_sec * ds.stpr_completed  ) / sum (ds.stpr_completed) duration_max_sec
-from   flow_instance_stats ds
-where  ds.stpr_period = 'MONTH'
-group by stpr_dgrm_id, trunc(stpr_period_start, 'Q')
-order by stpr_dgrm_id, trunc(stpr_period_start, 'Q')
-)
-select mon.stpr_dgrm_id
-     , mon.period_start
-     , 'QUARTER' as period
-     , mon.stpr_created
-     , mon.stpr_started
-     , mon.stpr_error
-     , mon.stpr_completed
-     , mon.stpr_terminated
-     , mon.stpr_reset
-     , numtoDSinterval( mon.duration_10pc_sec, 'SECOND' )
-     , numtoDSinterval( mon.duration_50pc_sec, 'SECOND' )
-     , numtoDSinterval( mon.duration_90pc_sec, 'SECOND' )
-     , numtoDSinterval( mon.duration_max_sec , 'SECOND' )
-     , mon.duration_10pc_sec
-     , mon.duration_50pc_sec
-     , mon.duration_90pc_sec
-     , mon.duration_max_sec
-from mon
-
-
-end flow_statistics;
-
--- instance stats query - showing quarterly, monthly and daily summaries
+/*-- instance stats query - showing quarterly, monthly and daily summaries
 
 -- used to drive process performance history charts on engine app p16
 --  current day statistics are based on live data
@@ -632,3 +648,213 @@ union all
         and  lgsf_sbfl_dgrm_id = :P17_DGRM_ID
         and  lgsf_objt_id = :P17_OBJT_BPMN_ID
         group by lgsf_sbfl_dgrm_id, lgsf_objt_id
+*/
+
+       function get_last_successful_summary
+       ( p_type  flow_stats_history.sths_type%type)
+       return date
+       is
+         l_last_successful_summary  date;
+       begin
+         select nvl( trunc( max( sths.sths_date)), to_date('01-JAN-2020','DD-MON-YYYY'))
+             -- deemed start of Flows for APEX epoch!
+           into l_last_successful_summary
+           from flow_stats_history sths
+          where sths.sths_type = p_type
+            and sths.sths_status = flow_constants_pkg.gc_stats_outcome_success
+         ;
+         return l_last_successful_summary;
+       exception
+         when no_data_found then
+           return to_date('01-JAN-2020','DD-MON-YYYY'); -- deemed start of Flows for APEX epoch!
+       end get_last_successful_summary;
+
+
+
+       procedure create_daily_summaries
+       ( p_start_date    in  date
+       )
+       is
+       begin
+         -- creates daily Summaries for all days between last successful run up to yesterday
+         -- create daily instance summary
+         create_daily_instance_summary (p_start_date => p_start_date);
+         -- create daily step summary
+         create_daily_step_summary (p_start_date => p_start_date);
+       end create_daily_summaries;
+
+       procedure create_monthly_summaries
+       ( p_start_date   in date)
+       is
+       begin
+         -- creates monthly Summaries for all months between last successful run up to yesterday
+         -- create monthly instance summary
+         create_monthly_instance_summaries (p_start_date => p_start_date);
+         -- create monthly step summary
+         create_monthly_step_summaries (p_start_date => p_start_date);         --
+       end create_monthly_summaries;
+
+       procedure create_quarterly_summaries
+       is
+         l_last_summary_date  date;
+         l_start_date         date;
+         l_final_quarter      date;  -- final quarter start date included in this new summary
+       begin
+         -- get last successful quarterly summmary date
+         l_last_summary_date := get_last_successful_summary (p_type => flow_constants_pkg.gc_stats_period_quarter);
+         l_start_date := add_months (l_last_summary_date, 3);
+         -- create quarterly instance summary
+         create_quarterly_instance_summaries (p_start_date => l_start_date);
+         -- create quarterly step summary
+         create_quarterly_step_summaries (p_start_date => l_start_date);     
+         -- set last quarterly summary in hstory
+         l_final_quarter := add_months( trunc(sysdate,'Q') , -3);
+
+         insert into flow_stats_history
+         ( sths_date 
+         , sths_status
+         , sths_type
+         , sths_errors
+         , sths_created_on
+         )
+         values 
+         ( l_final_quarter
+         , flow_constants_pkg.gc_stats_outcome_success
+         , flow_constants_pkg.gc_stats_period_quarter
+         , null
+         , systimestamp
+         )
+         ;
+
+       end create_quarterly_summaries;       
+
+       procedure run_daily_stats
+       is
+         l_last_successful_daily     date;
+       begin
+         -- get last successfully completed day
+         l_last_successful_daily := get_last_successful_summary 
+                                          (p_type => flow_constants_pkg.gc_stats_period_day);
+         -- make daily summaries from last successfully completed day to yesterday night
+         create_daily_summaries (p_start_date => l_last_successful_daily +1 );
+         -- run monthly and MTD summary
+         create_monthly_summaries (p_start_date => l_last_successful_daily +1 );
+         -- run quartlies if required
+         if trunc(l_last_successful_daily,'Q') != trunc(sysdate,'Q') then
+              create_quarterly_summaries ;
+         end if;
+         -- if successful update Stats history
+         insert into flow_stats_history
+         ( sths_date 
+         , sths_status
+         , sths_type
+         , sths_errors
+         , sths_created_on
+         )
+         values 
+         ( trunc(sys_extract_utc(systimestamp))-1
+         , flow_constants_pkg.gc_stats_outcome_success
+         , flow_constants_pkg.gc_stats_period_day
+         , null
+         , systimestamp
+         );
+         -- end
+       end run_daily_stats;
+
+  procedure purge_statistics
+  is
+    l_daily_summary_purge_date      date;
+    l_monthly_summary_purge_date    date;
+    l_quarterly_summary_purge_date  date;
+  begin
+    apex_debug.enter(p_routine_name  => 'purge_statistics');
+
+    l_daily_summary_purge_date      := sysdate - flow_engine_util.get_config_value
+                                      ( p_config_key => flow_constants_pkg.gc_config_log_retain_summary_daily 
+                                      , p_default_value => flow_constants_pkg.gc_config_default_log_retain_summary_daily   
+                                      );
+    l_monthly_summary_purge_date    := add_months ( sysdate, -1 * flow_engine_util.get_config_value
+                                                      ( p_config_key => flow_constants_pkg.gc_config_log_retain_summary_month 
+                                                      , p_default_value => flow_constants_pkg.gc_config_default_log_retain_summary_month  
+                                                      )
+                                                  );                                      
+    l_quarterly_summary_purge_date  := add_months ( sysdate, -1 * flow_engine_util.get_config_value
+                                                      ( p_config_key => flow_constants_pkg.gc_config_log_retain_summary_qtr 
+                                                      , p_default_value => flow_constants_pkg.gc_config_default_log_retain_summary_qtr  
+                                                      )
+                                                  );
+
+    apex_debug.message
+    ( p_message => 'Statistics purge starting for daily before %0, monthly before %1 and quarterly before %2'
+    , p0 => to_char(l_daily_summary_purge_date)
+    , p1 => to_char(l_monthly_summary_purge_date)
+    , p2 => to_char(l_quarterly_summary_purge_date)
+    );
+    --
+    begin
+      -- dailies
+      delete from flow_instance_stats
+      where stpr_period = flow_constants_pkg.gc_stats_period_day
+      and stpr_period_start < l_daily_summary_purge_date;
+
+      delete from flow_step_stats
+      where stsf_period = flow_constants_pkg.gc_stats_period_day
+      and stsf_period_start < l_daily_summary_purge_date;
+
+      -- monthlies
+      delete from flow_instance_stats
+      where stpr_period = flow_constants_pkg.gc_stats_period_month
+      and stpr_period_start < l_monthly_summary_purge_date;
+
+      delete from flow_step_stats
+      where stsf_period = flow_constants_pkg.gc_stats_period_month
+      and stsf_period_start < l_monthly_summary_purge_date;
+
+      -- quarterlies
+      delete from flow_instance_stats
+      where stpr_period = flow_constants_pkg.gc_stats_period_quarter
+      and stpr_period_start < l_quarterly_summary_purge_date;
+
+      delete from flow_step_stats
+      where stsf_period = flow_constants_pkg.gc_stats_period_quarter
+      and stsf_period_start < l_quarterly_summary_purge_date;
+      --
+      insert into flow_stats_history
+        ( sths_date
+        , sths_status
+        , sths_type
+        , sths_comments
+        , sths_created_on
+        )
+      values
+        ( sysdate
+        , flow_constants_pkg.gc_stats_outcome_success
+        , flow_constants_pkg.gc_stats_period_day
+        , 'purge completed'
+        , systimestamp
+        );        
+    end;
+    exception
+      when others then
+        insert into flow_stats_history
+        ( sths_date
+        , sths_status
+        , sths_type
+        , sths_comments
+        , sths_errors
+        , sths_created_on
+        )
+        values
+        ( sysdate
+        , flow_constants_pkg.gc_stats_outcome_error
+        , flow_constants_pkg.gc_stats_period_day
+        , 'error on purge'
+        , dbms_utility.format_error_stack
+        , systimestamp
+        ); 
+        raise;  
+  end purge_statistics;
+
+
+end flow_statistics;
+/

--- a/src/plsql/flow_statistics.pkb
+++ b/src/plsql/flow_statistics.pkb
@@ -1,0 +1,634 @@
+create or replace package body flow_statistics
+as
+/* 
+-- Flows for APEX - flow_statistics.pkb
+-- 
+-- (c) Copyright Oracle Corporation and / or its affiliates, 2023.
+--
+-- Created    11-Jan-2023  Richard Allen (Oracle)
+--
+*/
+
+procedure collect_step_statistics
+
+
+------------------
+---  collect daily step stats
+-------------------
+
+insert into flow_step_stats 
+        ( stsf_dgrm_id
+        , stsf_tag_name
+        , stsf_objt_bpmn_id
+        , stsf_period_start
+        , stsf_period
+        , stsf_duration_10pc_ivl
+        , stsf_duration_50pc_ivl
+        , stsf_duration_90pc_ivl
+        , stsf_duration_max_ivl
+        , stsf_duration_10pc_sec
+        , stsf_duration_50pc_sec
+        , stsf_duration_90pc_sec
+        , stsf_duration_max_sec
+        , stsf_waiting_10pc_ivl
+        , stsf_waiting_50pc_ivl
+        , stsf_waiting_90pc_ivl
+        , stsf_waiting_max_ivl
+        , stsf_waiting_10pc_sec
+        , stsf_waiting_50pc_sec
+        , stsf_waiting_90pc_sec
+        , stsf_waiting_max_sec  
+        , stsf_completed
+        ) 
+with ivl_stats as
+  ( select  lgsf_sbfl_dgrm_id                                                   as dgrm_id
+            , objt.objt_tag_name                                                as objt_tag_name
+            , lgsf_objt_id                                                      as objt_bpmn_id
+            , trunc (sys_extract_utc ( lgsf_completed ))                        as period_start
+            , approx_percentile (0.10 )
+                within group (order by (lgsf_completed - lgsf_was_current) ASC) as duration_10pc_ivl
+            , approx_percentile (0.50 )
+                within group (order by lgsf_completed - lgsf_was_current ASC)   as duration_50pc_ivl
+            , approx_percentile (0.90 )
+                within group (order by lgsf_completed - lgsf_was_current ASC)   as duration_90pc_ivl
+            , max ( lgsf_completed - lgsf_was_current)                          as duration_max_ivl
+            , approx_percentile (0.10 )
+                within group (order by (lgsf_started - lgsf_was_current) ASC)   as waiting_10pc_ivl
+            , approx_percentile (0.50 )
+                within group (order by lgsf_started - lgsf_was_current ASC)     as waiting_50pc_ivl
+            , approx_percentile (0.90 )
+                within group (order by lgsf_started - lgsf_was_current ASC)     as waiting_90pc_ivl
+            , max ( lgsf_started - lgsf_was_current)                            as waiting_max_ivl
+            , count (*)                                                         as completed
+       from flow_step_event_log lgsf
+  left join flow_objects objt
+         on objt.objt_dgrm_id = lgsf.lgsf_sbfl_dgrm_id
+        and objt.objt_bpmn_id = lgsf.lgsf_objt_id
+      where objt.objt_tag_name in ( 'bpmn:userTask', 'bpmn:serviceTask', 'bpmn:manualTask'
+                                  , 'bpmn:subProcess', 'bpmn:callActivity', 'bpmn:scriptTask', 'bpmn:task')
+   group by lgsf_sbfl_dgrm_id, objt.objt_tag_name, lgsf_objt_id, trunc (sys_extract_utc ( lgsf_completed ))
+  )
+select i.dgrm_id, i.objt_tag_name, i.objt_bpmn_id, i.period_start, 'DAY'
+     , i.duration_10pc_ivl
+     , i.duration_50pc_ivl
+     , i.duration_90pc_ivl
+     , i.duration_max_ivl
+     , flow_api_pkg.intervaldstosec (p_intervalds  => i.duration_10pc_ivl)
+     , flow_api_pkg.intervaldstosec (p_intervalds  => i.duration_50pc_ivl)
+     , flow_api_pkg.intervaldstosec (p_intervalds  => i.duration_90pc_ivl)
+     , flow_api_pkg.intervaldstosec (p_intervalds  => i.duration_max_ivl)
+     , i.waiting_10pc_ivl
+     , i.waiting_50pc_ivl
+     , i.waiting_90pc_ivl
+     , i.waiting_max_ivl
+     , flow_api_pkg.intervaldstosec (p_intervalds  => i.waiting_10pc_ivl)
+     , flow_api_pkg.intervaldstosec (p_intervalds  => i.waiting_50pc_ivl)
+     , flow_api_pkg.intervaldstosec (p_intervalds  => i.waiting_90pc_ivl)
+     , flow_api_pkg.intervaldstosec (p_intervalds  => i.waiting_max_ivl) 
+     , i.completed 
+from ivl_stats i
+;
+
+-- monthly step stats
+
+insert into flow_step_stats 
+        ( stsf_dgrm_id
+        , stsf_tag_name
+        , stsf_objt_bpmn_id
+        , stsf_period_start
+        , stsf_period
+        , stsf_duration_10pc_ivl
+        , stsf_duration_50pc_ivl
+        , stsf_duration_90pc_ivl
+        , stsf_duration_max_ivl
+        , stsf_duration_10pc_sec
+        , stsf_duration_50pc_sec
+        , stsf_duration_90pc_sec
+        , stsf_duration_max_sec
+        , stsf_waiting_10pc_ivl
+        , stsf_waiting_50pc_ivl
+        , stsf_waiting_90pc_ivl
+        , stsf_waiting_max_ivl
+        , stsf_waiting_10pc_sec
+        , stsf_waiting_50pc_sec
+        , stsf_waiting_90pc_sec
+        , stsf_waiting_max_sec  
+        , stsf_completed
+        )
+with mon as 
+(
+select stsf_dgrm_id, 
+       stsf_tag_name,
+       stsf_objt_bpmn_id,
+       trunc(stsf_period_start, 'MM') period_start, 
+       sum ( ds.stsf_duration_10pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_10pc_sec,
+       sum ( ds.stsf_duration_50pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_50pc_sec, 
+       sum ( ds.stsf_duration_90pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_90pc_sec, 
+       sum ( ds.stsf_duration_max_sec  * ds.stsf_completed ) / sum (ds.stsf_completed) duration_max_sec,
+       sum ( ds.stsf_waiting_10pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_10pc_sec,
+       sum ( ds.stsf_waiting_50pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_50pc_sec, 
+       sum ( ds.stsf_waiting_90pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_90pc_sec, 
+       sum ( ds.stsf_waiting_max_sec  * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_max_sec,
+       sum ( stsf_completed) stsf_completed
+from   flow_step_stats ds
+where  ds.stsf_period = 'DAY'
+group by stsf_dgrm_id, stsf_tag_name, stsf_objt_bpmn_id, trunc(stsf_period_start, 'MM')
+order by stsf_dgrm_id, stsf_tag_name, stsf_objt_bpmn_id, trunc(stsf_period_start, 'MM')
+)
+select mon.stsf_dgrm_id
+     , mon.stsf_tag_name
+     , mon.stsf_objt_bpmn_id
+     , mon.period_start
+     , 'MONTH' as period
+     , numtodsinterval (mon.duration_10pc_sec , 'SECOND') as duration_10pc_ivl
+     , numtodsinterval (mon.duration_50pc_sec , 'SECOND') as duration_50pc_ivl
+     , numtodsinterval (mon.duration_90pc_sec , 'SECOND') as duration_90pc_ivl
+     , numtodsinterval (mon.duration_max_sec  , 'SECOND') as duration_max_ivl
+     , mon.duration_10pc_sec
+     , mon.duration_50pc_sec
+     , mon.duration_90pc_sec
+     , mon.duration_max_sec
+     , numtodsinterval (mon.waiting_10pc_sec , 'SECOND') as waiting_10pc_ivl
+     , numtodsinterval (mon.waiting_50pc_sec , 'SECOND') as waiting_50pc_ivl
+     , numtodsinterval (mon.waiting_90pc_sec , 'SECOND') as waiting_90pc_ivl
+     , numtodsinterval (mon.waiting_max_sec  , 'SECOND') as waiting_max_ivl
+     , mon.waiting_10pc_sec
+     , mon.waiting_50pc_sec
+     , mon.waiting_90pc_sec
+     , mon.waiting_max_sec
+     , mon.stsf_completed
+from mon;
+
+-- quarter step stats
+
+insert into flow_step_stats 
+        ( stsf_dgrm_id
+        , stsf_tag_name
+        , stsf_objt_bpmn_id
+        , stsf_period_start
+        , stsf_period
+        , stsf_duration_10pc_ivl
+        , stsf_duration_50pc_ivl
+        , stsf_duration_90pc_ivl
+        , stsf_duration_max_ivl
+        , stsf_duration_10pc_sec
+        , stsf_duration_50pc_sec
+        , stsf_duration_90pc_sec
+        , stsf_duration_max_sec
+        , stsf_waiting_10pc_ivl
+        , stsf_waiting_50pc_ivl
+        , stsf_waiting_90pc_ivl
+        , stsf_waiting_max_ivl
+        , stsf_waiting_10pc_sec
+        , stsf_waiting_50pc_sec
+        , stsf_waiting_90pc_sec
+        , stsf_waiting_max_sec  
+        , stsf_completed
+        )
+with mon as 
+(
+select stsf_dgrm_id, 
+       stsf_tag_name,
+       stsf_objt_bpmn_id,
+       trunc(stsf_period_start, 'Q') period_start, 
+       sum ( ds.stsf_duration_10pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_10pc_sec,
+       sum ( ds.stsf_duration_50pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_50pc_sec, 
+       sum ( ds.stsf_duration_90pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) duration_90pc_sec, 
+       sum ( ds.stsf_duration_max_sec  * ds.stsf_completed ) / sum (ds.stsf_completed) duration_max_sec,
+       sum ( ds.stsf_waiting_10pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_10pc_sec,
+       sum ( ds.stsf_waiting_50pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_50pc_sec, 
+       sum ( ds.stsf_waiting_90pc_sec * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_90pc_sec, 
+       sum ( ds.stsf_waiting_max_sec  * ds.stsf_completed ) / sum (ds.stsf_completed) waiting_max_sec,
+       sum ( stsf_completed) stsf_completed
+from   flow_step_stats ds
+where  ds.stsf_period = 'MONTH'
+group by stsf_dgrm_id, stsf_tag_name, stsf_objt_bpmn_id, trunc(stsf_period_start, 'Q')
+order by stsf_dgrm_id, stsf_tag_name, stsf_objt_bpmn_id, trunc(stsf_period_start, 'Q')
+)
+select mon.stsf_dgrm_id
+     , mon.stsf_tag_name
+     , mon.stsf_objt_bpmn_id
+     , mon.period_start
+     , 'QUARTER' as period
+     , numtodsinterval (mon.duration_10pc_sec , 'SECOND') as duration_10pc_ivl
+     , numtodsinterval (mon.duration_50pc_sec , 'SECOND') as duration_50pc_ivl
+     , numtodsinterval (mon.duration_90pc_sec , 'SECOND') as duration_90pc_ivl
+     , numtodsinterval (mon.duration_max_sec  , 'SECOND') as duration_max_ivl
+     , mon.duration_10pc_sec
+     , mon.duration_50pc_sec
+     , mon.duration_90pc_sec
+     , mon.duration_max_sec
+     , numtodsinterval (mon.waiting_10pc_sec , 'SECOND') as waiting_10pc_ivl
+     , numtodsinterval (mon.waiting_50pc_sec , 'SECOND') as waiting_50pc_ivl
+     , numtodsinterval (mon.waiting_90pc_sec , 'SECOND') as waiting_90pc_ivl
+     , numtodsinterval (mon.waiting_max_sec  , 'SECOND') as waiting_max_ivl
+     , mon.waiting_10pc_sec
+     , mon.waiting_50pc_sec
+     , mon.waiting_90pc_sec
+     , mon.waiting_max_sec
+     , mon.stsf_completed
+from mon;
+
+
+------------------
+---  collect daily process stats
+-------------------
+insert into flow_instance_stats
+    ( stpr_dgrm_id    
+    , stpr_period_start  
+    , stpr_period
+    , stpr_created    
+    , stpr_started    
+    , stpr_error      
+    , stpr_completed  
+    , stpr_terminated 
+    , stpr_reset      
+    , stpr_duration_10pc_ivl
+    , stpr_duration_50pc_ivl
+    , stpr_duration_90pc_ivl
+    , stpr_duration_max_ivl 
+    , stpr_duration_10pc_sec
+    , stpr_duration_50pc_sec
+    , stpr_duration_90pc_sec
+    , stpr_duration_max_sec 
+    )
+with prcs_daily_totals as
+    (   select lgpr_dgrm_id dgrm_id
+             , trunc (sys_extract_utc (lgpr_timestamp )) period_start
+             , lgpr_prcs_event event
+             , count (*) times
+             , approx_percentile (0.10 )
+                    within group (order by (lgpr_duration) ASC) duration_10pc_ivl
+             , approx_percentile (0.50 )
+                    within group (order by (lgpr_duration) ASC) duration_50pc_ivl
+             , approx_percentile (0.90 )
+                    within group (order by (lgpr_duration) ASC) duration_90pc_ivl
+             , max (lgpr_duration) duration_Max_ivl
+        from flow_instance_event_log lgpr
+        where lgpr.lgpr_prcs_event in ('created','started', 'error', 'completed', 'terminated', 'reset')
+        group by lgpr_dgrm_id
+               , trunc (sys_extract_utc (lgpr_timestamp )) 
+               , lgpr_prcs_event
+        order by lgpr_dgrm_id
+               , trunc (sys_extract_utc (lgpr_timestamp )) 
+               , lgpr_prcs_event 
+    ),
+prcs_pivot_totals as 
+    (    select * from 
+            (select dgrm_id, period_start, event, times 
+            from prcs_daily_totals
+            ) tot pivot (sum (times)
+            for event in ('created' as CREATED, 'started' as STARTED, 'error' as ERROR, 'completed' as COMPLETED, 'terminated' as TERMINATED, 'reset' as RESET))
+        order by dgrm_id  
+    )
+select t.dgrm_id, t.period_start,  'DAY' 
+     , p.created, p.started, p.error, p.completed, p.terminated, p.reset
+     , t.duration_10pc_ivl
+     , t.duration_50pc_ivl
+     , t.duration_90pc_ivl
+     , t.duration_Max_ivl
+     , flow_api_pkg.intervalDStoSec (t.duration_10pc_ivl) duration_10pc_sec
+     , flow_api_pkg.intervalDStoSec (t.duration_50pc_ivl) duration_50pc_sec
+     , flow_api_pkg.intervalDStoSec (t.duration_90pc_ivl) duration_90pc_sec
+     , flow_api_pkg.intervalDStoSec (t.duration_max_ivl ) duration_max_sec
+ from  prcs_pivot_totals p
+ join  prcs_daily_totals t
+   on  t.dgrm_id = p.dgrm_id
+  and  t.period_start = p.period_start
+where  t.event = 'completed'
+
+-- alternate daily stats
+with prcs_daily_totals as
+    (   select lgpr_dgrm_id dgrm_id
+             , trunc (sys_extract_utc (sysdate )) period_start
+             , lgpr_prcs_event event
+             , count (*) times
+             , approx_percentile (0.10 )
+                    within group (order by (lgpr_duration) ASC) duration_10pc_ivl
+             , approx_percentile (0.50 )
+                    within group (order by (lgpr_duration) ASC) duration_50pc_ivl
+             , approx_percentile (0.90 )
+                    within group (order by (lgpr_duration) ASC) duration_90pc_ivl
+             , max (lgpr_duration) duration_Max_ivl
+             , sum ( case lgpr_prcs_event when 'created' then 1 else 0 end) num_created
+        from flow_instance_event_log lgpr
+        where lgpr.lgpr_prcs_event in ('created','started', 'error', 'completed', 'terminated', 'reset')
+        group by lgpr_dgrm_id
+               , trunc (sys_extract_utc (sysdate )) 
+               , lgpr_prcs_event
+        order by lgpr_dgrm_id
+               , trunc (sys_extract_utc (sysdate )) 
+               , lgpr_prcs_event 
+    ),
+prcs_pivot_totals as 
+    (    select * from 
+            (select dgrm_id, period_start, event, times 
+            from prcs_daily_totals
+            ) tot pivot (sum (times)
+            for event in ('created' as CREATED, 'started' as STARTED, 'error' as ERROR, 'completed' as COMPLETED, 'terminated' as TERMINATED, 'reset' as RESET))
+        order by dgrm_id  
+    )
+select t.dgrm_id, t.period_start,  'DAY' 
+     , p.created, p.started, p.error, p.completed, p.terminated, p.reset
+     , t.duration_10pc_ivl
+     , t.duration_50pc_ivl
+     , t.duration_90pc_ivl
+     , t.duration_Max_ivl
+     , flow_api_pkg.intervalDStoSec (t.duration_10pc_ivl) duration_10pc_sec
+     , flow_api_pkg.intervalDStoSec (t.duration_50pc_ivl) duration_50pc_sec
+     , flow_api_pkg.intervalDStoSec (t.duration_90pc_ivl) duration_90pc_sec
+     , flow_api_pkg.intervalDStoSec (t.duration_max_ivl ) duration_max_sec
+ from  prcs_pivot_totals p
+ join  prcs_daily_totals t
+   on  t.dgrm_id = p.dgrm_id
+  and  t.period_start = p.period_start
+where  t.event = 'completed'
+
+
+-- creeate monthly instance summaries
+
+insert into flow_instance_stats
+    ( stpr_dgrm_id    
+    , stpr_period_start  
+    , stpr_period
+    , stpr_created    
+    , stpr_started    
+    , stpr_error      
+    , stpr_completed  
+    , stpr_terminated 
+    , stpr_reset      
+    , stpr_duration_10pc_ivl
+    , stpr_duration_50pc_ivl
+    , stpr_duration_90pc_ivl
+    , stpr_duration_max_ivl 
+    , stpr_duration_10pc_sec
+    , stpr_duration_50pc_sec
+    , stpr_duration_90pc_sec
+    , stpr_duration_max_sec 
+    )
+with mon as 
+(
+select stpr_dgrm_id, 
+       trunc(stpr_period_start, 'MM') period_start, 
+       sum (stpr_created) stpr_created,
+       sum (stpr_started) stpr_started,
+       sum (stpr_error) stpr_error,
+       sum (stpr_completed) stpr_completed,
+       sum (stpr_terminated) stpr_terminated,
+       sum (stpr_reset) stpr_reset,
+       sum ( ds.stpr_duration_10pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_10pc_sec,
+       sum ( ds.stpr_duration_50pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_50pc_sec, 
+       sum ( ds.stpr_duration_90pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_90pc_sec, 
+       sum ( ds.stpr_duration_max_sec * ds.stpr_completed  ) / sum (ds.stpr_completed) duration_max_sec
+from   flow_instance_stats ds
+where  ds.stpr_period = 'DAY'
+group by stpr_dgrm_id, trunc(stpr_period_start, 'MM')
+order by stpr_dgrm_id, trunc(stpr_period_start, 'MM')
+)
+select mon.stpr_dgrm_id
+     , mon.period_start
+     , 'MONTH' as period
+     , mon.stpr_created
+     , mon.stpr_started
+     , mon.stpr_error
+     , mon.stpr_completed
+     , mon.stpr_terminated
+     , mon.stpr_reset
+     , numtoDSinterval( mon.duration_10pc_sec, 'SECOND' )
+     , numtoDSinterval( mon.duration_50pc_sec, 'SECOND' )
+     , numtoDSinterval( mon.duration_90pc_sec, 'SECOND' )
+     , numtoDSinterval( mon.duration_max_sec , 'SECOND' )
+     , mon.duration_10pc_sec
+     , mon.duration_50pc_sec
+     , mon.duration_90pc_sec
+     , mon.duration_max_sec
+from mon
+
+-- quarter summary
+
+insert into flow_instance_stats
+    ( stpr_dgrm_id    
+    , stpr_period_start  
+    , stpr_period
+    , stpr_created    
+    , stpr_started    
+    , stpr_error      
+    , stpr_completed  
+    , stpr_terminated 
+    , stpr_reset      
+    , stpr_duration_10pc_ivl
+    , stpr_duration_50pc_ivl
+    , stpr_duration_90pc_ivl
+    , stpr_duration_max_ivl 
+    , stpr_duration_10pc_sec
+    , stpr_duration_50pc_sec
+    , stpr_duration_90pc_sec
+    , stpr_duration_max_sec 
+    )
+with mon as 
+(
+select stpr_dgrm_id, 
+       trunc(stpr_period_start, 'Q') period_start, 
+       sum (stpr_created) stpr_created,
+       sum (stpr_started) stpr_started,
+       sum (stpr_error) stpr_error,
+       sum (stpr_completed) stpr_completed,
+       sum (stpr_terminated) stpr_terminated,
+       sum (stpr_reset) stpr_reset,
+       sum ( ds.stpr_duration_10pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_10pc_sec,
+       sum ( ds.stpr_duration_50pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_50pc_sec, 
+       sum ( ds.stpr_duration_90pc_sec * ds.stpr_completed ) / sum (ds.stpr_completed) duration_90pc_sec, 
+       sum ( ds.stpr_duration_max_sec * ds.stpr_completed  ) / sum (ds.stpr_completed) duration_max_sec
+from   flow_instance_stats ds
+where  ds.stpr_period = 'MONTH'
+group by stpr_dgrm_id, trunc(stpr_period_start, 'Q')
+order by stpr_dgrm_id, trunc(stpr_period_start, 'Q')
+)
+select mon.stpr_dgrm_id
+     , mon.period_start
+     , 'QUARTER' as period
+     , mon.stpr_created
+     , mon.stpr_started
+     , mon.stpr_error
+     , mon.stpr_completed
+     , mon.stpr_terminated
+     , mon.stpr_reset
+     , numtoDSinterval( mon.duration_10pc_sec, 'SECOND' )
+     , numtoDSinterval( mon.duration_50pc_sec, 'SECOND' )
+     , numtoDSinterval( mon.duration_90pc_sec, 'SECOND' )
+     , numtoDSinterval( mon.duration_max_sec , 'SECOND' )
+     , mon.duration_10pc_sec
+     , mon.duration_50pc_sec
+     , mon.duration_90pc_sec
+     , mon.duration_max_sec
+from mon
+
+
+end flow_statistics;
+
+-- instance stats query - showing quarterly, monthly and daily summaries
+
+-- used to drive process performance history charts on engine app p16
+--  current day statistics are based on live data
+--  next previous 6 days summaries 
+--  current month and previous 3-6 months summary data (depending on where month lies in the quarter)
+--  quarterly summary data before that for upto 4 quarters
+--  note that label value is in a specific format so that all of the sets sort into the correct calender order
+
+with summary_dates as
+(
+    select trunc(sysdate) - 7 + level dt, 'DAY' as period, 8-level sort_order
+    from dual
+    connect by level <= ( sysdate - sysdate +7)
+    union
+    select add_months( trunc(sysdate,'MM')
+                     , - floor (months_between ( trunc ( sysdate)
+                                               , trunc ( add_months(sysdate,-6) , 'Q')
+                                               ) - 3
+                                ) + level-1
+                     )
+                     ,'MONTH'
+                     , 10*(7-level)
+    from dual
+    connect by level <= ( sysdate - sysdate + floor (months_between ( trunc (sysdate)
+                                                                    , trunc (add_months ( sysdate ,-6) , 'Q')
+                                                                    ) - 2
+                                                    )
+                        )
+    union 
+    select add_months(trunc(sysdate,'Q'), -3 - (3*level)),'QUARTER', 100*level
+    from dual
+    connect by level <= (sysdate -sysdate +4)
+)
+select sd.dt, 
+       sd.period, 
+       case sd.period
+          when 'DAY'     then to_char(dt,'YYYY-MM-DD')
+          when 'MONTH'   then to_char(dt,'YYYY-MM')
+          when 'QUARTER' then to_char(dt,'YYYY-"0"Q')
+       end PeriodLabel,
+       sd.sort_order,
+       ist.stpr_created,
+       ist.stpr_started,
+       ist.stpr_completed,
+       ist.stpr_error,
+       ist.stpr_terminated,
+       ist.stpr_reset,
+       ist.stpr_duration_10pc_sec,
+       ist.stpr_duration_50pc_sec,
+       ist.stpr_duration_90pc_sec,
+       ist.stpr_duration_max_sec
+  from summary_dates sd
+  left join flow_instance_stats ist
+    on sd.dt     = ist.stpr_period_start
+   and sd.period = ist.stpr_period
+ where ist.stpr_dgrm_id = :P16_DGRM_ID
+ order by sd.sort_order desc
+union all
+   select trunc(sysdate)
+        , 'DAY'
+        , to_char (sysday,'YYYY-MM-DD')
+        , 0
+        , sum ( case lgpr_prcs_event when 'created'    then 1 else 0 end) num_created
+        , sum ( case lgpr_prcs_event when 'started'    then 1 else 0 end) num_started
+        , sum ( case lgpr_prcs_event when 'completed'  then 1 else 0 end) num_completed
+        , sum ( case lgpr_prcs_event when 'error    '  then 1 else 0 end) num_error
+        , sum ( case lgpr_prcs_event when 'terminated' then 1 else 0 end) num_terminated
+        , sum ( case lgpr_prcs_event when 'reset'      then 1 else 0 end) num_reset
+        , flow_api_pkg.intervaldstosec ( approx_percentile (0.10 )
+               within group (order by (lgpr_duration) ASC)) duration_10pc_sec
+        , flow_api_pkg.intervaldstosec ( approx_percentile (0.50 )
+               within group (order by (lgpr_duration) ASC)) duration_50pc_sec             
+        , flow_api_pkg.intervaldstosec ( approx_percentile (0.90 )
+               within group (order by (lgpr_duration) ASC)) duration_90pc_sec             
+        , flow_api_pkg.intervaldstosec ( max (lgpr_duration)) duration_max_sec                                  
+         from flow_instance_event_log lgpr
+        where lgpr.lgpr_prcs_event in ('created','started', 'error', 'completed', 'terminated', 'reset')
+        and   trunc (sys_extract_utc(lgpr_timestamp)) = trunc(sysdate)
+        and  lgpr_dgrm_id = :P16_DGRM_ID
+        group by lgpr_dgrm_id
+        order by lgpr_dgrm_id
+;
+
+-- step stats query - showing quarterly, monthly and daily summaries
+
+-- used to drive process performance history charts on engine app p17
+--  current day statistics are based on live data
+--  next previous 6 days summaries 
+--  current month and previous 3-6 months summary data (depending on where month lies in the quarter)
+--  quarterly summary data before that for upto 4 quarters
+--  note that label value is in a specific format so that all of the sets sort into the correct calender order
+
+with summary_dates as
+(
+    select trunc(sysdate) - 7 + level dt, 'DAY' as period, 8-level sort_order
+    from dual
+    connect by level <= ( sysdate - sysdate +7)
+    union
+    select add_months( trunc(sysdate,'MM')
+                     , - floor (months_between ( trunc ( sysdate)
+                                               , trunc ( add_months(sysdate,-6) , 'Q')
+                                               ) - 3
+                                ) + level-1
+                     )
+                     ,'MONTH'
+                     , 10*(7-level)
+    from dual
+    connect by level <= ( sysdate - sysdate + floor (months_between ( trunc (sysdate)
+                                                                    , trunc (add_months ( sysdate ,-6) , 'Q')
+                                                                    ) - 2
+                                                    )
+                        )
+    union 
+    select add_months(trunc(sysdate,'Q'), -3 - (3*level)),'QUARTER', 100*level
+    from dual
+    connect by level <= (sysdate -sysdate +4)
+)
+select sd.dt, 
+       sd.period, 
+       case sd.period
+          when 'DAY'     then to_char(dt,'YYYY-MM-DD')
+          when 'MONTH'   then to_char(dt,'YYYY-MM')
+          when 'QUARTER' then to_char(dt,'YYYY-"0"Q')
+       end PeriodLabel,
+       sd.sort_order,
+       ist.stsf_completed,
+       ist.stsf_duration_10pc_sec,
+       ist.stsf_duration_50pc_sec,
+       ist.stsf_duration_90pc_sec,
+       ist.stsf_duration_max_sec,
+       ist.stsf_waiting_10pc_sec,
+       ist.stsf_waiting_50pc_sec,
+       ist.stsf_waiting_90pc_sec,
+       ist.stsf_waiting_max_sec
+  from summary_dates sd
+  left join flow_step_stats ist
+    on sd.dt     = ist.stsf_period_start
+   and sd.period = ist.stsf_period
+ where ist.stsf_dgrm_id = :P17_DGRM_ID
+   and ist.stsf_objt_bpmn_id = :P17_OBJT_BPMN_ID
+union all
+   select trunc(sysdate)
+        , 'DAY'
+        , to_char (sysdate,'YYYY-MM-DD')
+        , 0
+        , count(lgsf_prcs_id) num_completed
+        , flow_api_pkg.intervaldstosec ( approx_percentile (0.10 )
+               within group (order by (lgsf_completed - lgsf_was_current) ASC))   duration_10pc_sec
+        , flow_api_pkg.intervaldstosec ( approx_percentile (0.50 )
+               within group (order by (lgsf_completed - lgsf_was_current) ASC))   duration_50pc_sec             
+        , flow_api_pkg.intervaldstosec ( approx_percentile (0.90 )
+               within group (order by (lgsf_completed - lgsf_was_current) ASC))   duration_90pc_sec             
+        , flow_api_pkg.intervaldstosec ( max (lgsf_completed - lgsf_was_current)) duration_max_sec                                  
+        , flow_api_pkg.intervaldstosec ( approx_percentile (0.10 )
+               within group (order by (lgsf_started - lgsf_was_current) ASC))   waiting_10pc_sec
+        , flow_api_pkg.intervaldstosec ( approx_percentile (0.50 )
+               within group (order by (lgsf_started - lgsf_was_current) ASC))   waiting_50pc_sec             
+        , flow_api_pkg.intervaldstosec ( approx_percentile (0.90 )
+               within group (order by (lgsf_started - lgsf_was_current) ASC))   waiting_90pc_sec             
+        , flow_api_pkg.intervaldstosec ( max (lgsf_started - lgsf_was_current)) waiting_max_sec           
+        from flow_step_event_log lgsf
+        where trunc (sys_extract_utc(lgsf_completed)) = trunc(sysdate)
+        and  lgsf_sbfl_dgrm_id = :P17_DGRM_ID
+        and  lgsf_objt_id = :P17_OBJT_BPMN_ID
+        group by lgsf_sbfl_dgrm_id, lgsf_objt_id

--- a/src/plsql/flow_statistics.pks
+++ b/src/plsql/flow_statistics.pks
@@ -1,0 +1,18 @@
+create or replace package flow_statistics
+as
+/* 
+-- Flows for APEX - flow_statistics.pks
+-- 
+-- (c) Copyright Oracle Corporation and / or its affiliates, 2023.
+--
+-- Created    11-Jan-2023  Richard Allen (Oracle)
+--
+*/
+
+procedure collect_step_statistics
+
+
+
+
+
+end flow_statistics;

--- a/src/plsql/flow_statistics.pks
+++ b/src/plsql/flow_statistics.pks
@@ -1,4 +1,5 @@
 create or replace package flow_statistics
+accessible by ( flow_admin_api)
 as
 /* 
 -- Flows for APEX - flow_statistics.pks

--- a/src/plsql/flow_statistics.pks
+++ b/src/plsql/flow_statistics.pks
@@ -9,10 +9,10 @@ as
 --
 */
 
-procedure collect_step_statistics
+  procedure run_daily_stats;
 
-
-
+  procedure purge_statistics;
 
 
 end flow_statistics;
+/

--- a/src/views/engine-app/flow_p0020_instance_timeline_vw.sql
+++ b/src/views/engine-app/flow_p0020_instance_timeline_vw.sql
@@ -42,7 +42,8 @@ select prcs_id
         else 'Object '||objt||'  subflow ' ||subflow||' • variable '||proc_var||' • value '||value        
        end as event_desc
      , 'u-color-'||( ora_hash(objt,44) + 1 )||' '||
-      case operation
+        'fa fa-clock-o'
+/*      case operation
         when 'step current' then 'fa fa-circle-o'
         when 'step started' then 'fa fa-play-circle'
         when 'step completed' then 'fa fa-check-circle'
@@ -55,7 +56,7 @@ select prcs_id
         when 'Gateway Processed' then 'fa fa-index'
         when 'start called model' then 'fa fa-box-arrow-in-south'
         when 'finish called model' then 'fa fa-box-arrow-out-north'
-       end as USER_COLOR
+       end */ as USER_COLOR
      , case operation
         when 'step current' then 'fa fa-circle-o'
         when 'step started' then 'fa fa-play-circle-o'

--- a/src/views/engine-app/flow_p0020_instance_timeline_vw.sql
+++ b/src/views/engine-app/flow_p0020_instance_timeline_vw.sql
@@ -1,0 +1,80 @@
+create or replace view flow_p0020_instance_timeline_vw as
+select prcs_id
+     , to_char(performed_on, 'YYYY-MM-DD HH24:MI:SSXFF TZR') event_date
+     , lower(performed_by) user_name
+     , case operation
+        when 'variable set' then 'Variable "'||proc_var||'" set to "'||value||'".'
+        when 'step current' then 'Step '||objt||' became Current'
+        when 'step started' then 'Step '||objt||' started work'
+        when 'step completed' then 'Step '||objt||' completed'
+        when 'created' then 'Process Instance Created'
+        when 'started' then 'Process Instance Started'
+        else description
+       end as event_title
+     , operation as event_type
+     , case operation
+        when 'step current' then 'is-new'
+        when 'step started' then 'is-updated'
+        when 'step completed' then 'is-new'
+        when 'completed' then 'is-removed'
+        when 'started' then 'is-new'
+        when 'created' then 'is-new'
+        when 'reset' then 'is-removed'
+        when 'error' then 'is-removed'
+        when 'variable set' then 'is-updated'
+        when 'Gateway Processed' then 'is-updated'
+        when 'start called model' then 'is-new'
+        when 'finish called model' then 'is-new'
+       end as event_status
+     , case operation
+        when 'step current' then 'subflow '||subflow|| ' • process level '||process_level||nvl2(value,' • previous step  '||value,'')
+        when 'step started' then 'subflow '||subflow|| nvl2(value,' • reserved by '||value,' • not reserved')
+        when 'step completed' then null
+        when 'created' then 'process '||prcs_id||nvl2(value,' • name '||value,'')
+        when 'started' then 'process '||prcs_id||nvl2(value,' • name '||value,'')    
+        when 'variable set' then 
+                  nvl2(objt,'step '||objt||' ','')
+                ||nvl2(subflow,'• subflow '||subflow||' ','')
+                ||nvl2(event_comment,'• expression set '||event_comment,'')
+        when 'Gateway Processed' then 'subflow '||subflow||' • forward paths - '||event_comment
+        when 'start called model' then event_comment
+        when 'finish called model' then event_comment
+        else 'Object '||objt||'  subflow ' ||subflow||' • variable '||proc_var||' • value '||value        
+       end as event_desc
+     , 'u-color-'||( ora_hash(objt,44) + 1 )||' '||
+      case operation
+        when 'step current' then 'fa fa-circle-o'
+        when 'step started' then 'fa fa-play-circle'
+        when 'step completed' then 'fa fa-check-circle'
+        when 'completed' then 'fa fa-dot-circle'
+        when 'started' then 'fa fa-circle-o'
+        when 'created' then 'fa fa-server-new'
+        when 'reset' then 'fa fa-fast-backward'
+        when 'error' then 'fa fa-exclamation-circle'
+        when 'variable set' then 'fa fa-window-terminal'
+        when 'Gateway Processed' then 'fa fa-index'
+        when 'start called model' then 'fa fa-box-arrow-in-south'
+        when 'finish called model' then 'fa fa-box-arrow-out-north'
+       end as USER_COLOR
+     , case operation
+        when 'step current' then 'fa fa-circle-o'
+        when 'step started' then 'fa fa-play-circle-o'
+        when 'step completed' then 'fa fa-check-circle-o'
+        when 'completed' then 'fa fa-dot-circle'
+        when 'started' then 'fa fa-circle-o'
+        when 'created' then 'fa fa-server-new'
+        when 'reset' then 'fa fa-fast-backward'
+        when 'error' then 'fa fa-exclamation-circle'
+        when 'variable set' then 'fa fa-window-terminal'
+        when 'Gateway Processed' then 'fa fa-index'   
+        when 'start called model' then 'fa fa-box-arrow-in-south'
+        when 'finish called model' then 'fa fa-box-arrow-out-north'
+       end as event_icon
+     , operation
+     , objt
+     , proc_var
+     , value
+     , subflow
+     , process_level
+     , performed_by
+from flow_instance_timeline_vw 

--- a/src/views/flow_instance_summary_json_vw.sql
+++ b/src/views/flow_instance_summary_json_vw.sql
@@ -1,0 +1,114 @@
+create or replace view flow_instance_summary_json_vw as 
+ with s as
+                    (select distinct sc.lgvr_scope scope, sc.lgvr_prcs_id
+                    from   flow_variable_event_log sc
+                    )
+select prcs_id, prcs_status, systimestamp as json_created_date, 
+        json_object (
+    'processID'    : p.prcs_id,
+    'mainDiagram'  : p.prcs_dgrm_id,
+    'processName'  : p.prcs_name,
+    'businessID'   : prov.prov.prov_var_vc2,
+    'priority'     : p.prcs_priority,
+    'prcs_status'  : p.prcs_status,
+    'json_created' : systimestamp,
+    'prcs_init_ts' : p.prcs_init_ts,
+    'prcs_init_by' : p.prcs_init_by,
+    'prcs_due_on'  : p.prcs_due_on,
+    'diagramsUsed' :
+         (select json_arrayagg 
+                    ( json_object 
+                        (
+                        'diagramLevel'               value prdg_diagram_level,
+                        'diagramId'                  value prdg_dgrm_id,
+                        'diagramName'                value dgrm_name,
+                        'diagramVersion'             value dgrm_version,
+                        'diagramStatus'              value dgrm_status,
+                        'callingDiagram'             value prdg_calling_dgrm,
+                        'callingObject'              value prdg_calling_objt
+                        ) ORDER BY prdg_diagram_level asc 
+                    )
+            from flow_instance_diagrams prdg
+            join flow_diagrams dgrm
+              on dgrm.dgrm_id = prdg.prdg_dgrm_id
+           where prdg.prdg_prcs_id = p.prcs_id   
+        ),
+    'events' : 
+        (select json_arrayagg 
+                    ( json_object 
+                        (
+                        'event'                      value lgpr_prcs_event,
+                        'object'                     value lgpr_OBJT_ID,
+                        'diagram'                    value lgpr_DGRM_ID,
+                        'timestamp'                  value lgpr_timestamp,
+                        'user'                       value lgpr_USER,
+                        'error-info'                 value lgpr_ERROR_INFO,
+                        'comment'                    value lgpr_COMMENT absent on null
+                        ) ORDER BY lgpr_timestamp 
+                   returning clob )
+           from flow_instance_event_log lgpr
+          where lgpr.lgpr_prcs_id = p.prcs_id
+        ),       
+    'steps' :
+        (select json_arrayagg
+                    (json_object 
+                        (
+                        'object'                     VALUE LGSF_OBJT_ID,
+                        'subflowID'                  VALUE LGSF_SBFL_ID,
+                        'processLevel'               VALUE LGSF_SBFL_PROCESS_LEVEL,
+                        'priority'                   VALUE lgsf_priority,
+                        'lastCompleted'              VALUE LGSF_LAST_COMPLETED,
+                        'wasCurrent'                 VALUE LGSF_WAS_CURRENT,
+                        'wasStarted'                 VALUE LGSF_STARTED,
+                        'wasCompleted'               VALUE LGSF_COMPLETED,
+                        'statusWhenComplete'         VALUE LGSF_STATUS_WHEN_COMPLETE,
+                        'subflowDiagram'             VALUE LGSF_SBFL_DGRM_ID,
+                        'reservation'                VALUE LGSF_RESERVATION,
+                        'user'                       VALUE LGSF_USER,
+                        'comment'                    VALUE LGSF_COMMENT absent on null
+                        ) ORDER BY lgsf_was_current
+                    returning clob)
+          from flow_step_event_log lgsf
+         where lgsf.lgsf_prcs_id = p.prcs_id
+        ),
+    'processVariablesSet' :
+            (  select json_arrayagg (
+                    json_object (
+                        'scope'         : s.scope,
+                        'variables'     :
+                            ( select json_arrayagg 
+                                        (
+                                        json_object 
+                                            (
+                                            'var_name'        value lgvr.lgvr_var_name,
+                                            'subflowID'       value lgvr.lgvr_sbfl_id,
+                                            'objectId'        value lgvr.lgvr_objt_id,
+                                            'expr_set'        value lgvr.lgvr_expr_set,
+                                            'type'            value lgvr.lgvr_var_type,
+                                            'timestamp'       value lgvr.lgvr_timestamp,
+                                            'newValue'        value case lgvr.lgvr_var_type
+                                                                    when 'VARCHAR2'                   then lgvr.lgvr_var_vc2
+                                                                    when 'NUMBER'                     then to_char(lgvr.lgvr_var_num)
+                                                                    when 'DATE'                       then to_char(lgvr.lgvr_var_date,'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+                                                                    when 'TIMESTAMP WITH TIME ZONE'   then to_char(lgvr.lgvr_var_tstz,'YYYY-MM-DD"T"HH24:MI:SSTZR')
+                                                                    when 'CLOB'                       then 'CLOB Value'
+                                                                    end 
+                                            )
+                                        order by lgvr.lgvr_timestamp 
+                                        )
+                                from flow_variable_event_log lgvr
+                               where lgvr.lgvr_prcs_id = p.prcs_id
+                                 and lgvr.lgvr_scope   = s.scope
+                            )
+                        )
+                    returning clob )
+                from s
+               where s.lgvr_prcs_id = p.prcs_id
+            )
+        returning clob)  summary_json
+  from flow_processes p
+  left join flow_process_variables prov
+    on prov.prov_prcs_id    = p.prcs_id
+ where prov.prov_var_name   = 'BUSINESS_REF'
+   and prov.prov_scope      = 0
+;

--- a/src/views/flow_instance_timeline_vw.sql
+++ b/src/views/flow_instance_timeline_vw.sql
@@ -1,0 +1,114 @@
+create or replace view flow_instance_timeline_vw as
+select 'created' operation
+     , 'Instance Created' description
+     , null as objt
+     , null as subflow
+     , 0 as process_level
+     , null as proc_var
+     , prcs.prcs_name as value
+     , null as event_comment
+     , prcs_init_ts performed_on
+     , prcs_init_by performed_by
+     , prcs_id 
+  from flow_processes prcs
+union
+select 'started' operation
+     , 'Instance Started' description
+     , null as objt
+     , null as subflow
+     , 0 as process_level
+     , null as proc_var 
+     , prcs.prcs_name as value
+     , null as event_comment
+     , prcs_start_ts performed_on
+     , null
+     , prcs_id 
+  from flow_processes prcs
+union
+select 'completed' operation
+     , 'Instance completed' description
+     , null as objt
+     , null as subflow
+     , 0 as process_level
+     , null as proc_var
+     , null as value
+     , null as event_comment
+     , prcs_start_ts performed_on
+     , null
+     , prcs_id 
+  from flow_processes prcs
+ where prcs.prcs_complete_ts is not null
+union
+select lgpr_prcs_event operation
+     , lgpr_prcs_event 
+     , lgpr_objt_id
+     , null as subflow
+     , null as process_level
+     , null as proc_var
+     , null as value
+     , lgpr_comment as event_comment
+     , lgpr_timestamp performed_on
+     , lgpr_user
+     , lgpr_prcs_id as prcs_id
+  from    flow_instance_event_log lgpr
+union 
+select 'step current' as operation
+     , 'Became Current after' as description
+     , lgsf_objt_id as objt
+     , lgsf_sbfl_id as subflow
+     , lgsf_sbfl_process_level as process_level
+     , null as proc_var
+     , lgsf_last_completed as value
+     , lgsf_comment as event_comment
+     , lgsf_was_current as performed_on
+     , null as performed_by
+     , lgsf_prcs_id as prcs_id 
+  from flow_step_event_log
+union
+select 'step started' as operation
+     , 'Work Started on Step' description
+     , lgsf_objt_id as objt
+     , lgsf_sbfl_id as subflow
+     , lgsf_sbfl_process_level as process_level
+     , null as proc_var
+     , null as value
+     , lgsf_comment as event_comment
+     , lgsf_started as performed_on
+     , null as performed_by
+     , lgsf_prcs_id as prcs_id 
+  from flow_step_event_log
+ where lgsf_started is not null
+union 
+select 'step completed' as operation
+     , 'Step completed' description
+     , lgsf_objt_id as objt
+     , lgsf_sbfl_id as subflow
+     , lgsf_sbfl_process_level as process_level
+     , null as proc_var
+     , null as value
+     , lgsf_comment as event_comment
+     , lgsf_completed as performed_on
+     , lgsf_user as performed_by
+     , lgsf_prcs_id as prcs_id 
+  from flow_step_event_log   
+union 
+select 'variable set' as operation
+     , 'Variable set' as description
+     , lgvr_objt_id as objt
+     , lgvr_sbfl_id as subflow
+     , null as process_level
+     , lgvr_var_name as proc_var
+     , case lgvr_var_type 
+          when 'VARCHAR2' then lgvr_var_vc2
+          when 'NUMBER' then to_char(lgvr_var_num)
+          when 'DATE' then to_char (lgvr_var_date, 'DD-MON-YY HH24:MI:SS')
+          when 'TIMESTAMP WITH TIME ZONE' then to_char (lgvr_var_tstz, 'DD-MON-YY HH24:MI:SS TZR')
+          when 'CLOB' then 'CLOB Value'
+          end as value
+     , lgvr_expr_set as event_comment
+     , lgvr_timestamp as performed_on
+     , null as performed_by
+     , lgvr_prcs_id as prcs_id 
+  from    flow_variable_event_log
+order by performed_on
+with read only

--- a/src/views/flow_instances_vw.sql
+++ b/src/views/flow_instances_vw.sql
@@ -11,7 +11,9 @@ as
        , prcs.prcs_status
        , prcs.prcs_init_ts
        , prcs.prcs_init_by
+       , prcs.prcs_start_ts
        , prcs.prcs_due_on
+       , prcs.prcs_complete_ts
        , prcs.prcs_last_update
        , prcs.prcs_last_update_by
        , prov.prov_var_vc2 as prcs_business_ref

--- a/src/views/temp
+++ b/src/views/temp
@@ -1,0 +1,689 @@
+{
+    "processID": 7164,
+    "mainDiagram": 146,
+    "processName": "Export Parts Order - BA A320 Seating Refurb G994K ",
+    "businessID": "1006",
+    "priority": null,
+    "prcs_status": "running",
+    "json_created": "2023-02-01T10:53:41.681732Z",
+    "prcs_init_ts": "2022-12-02T06:40:12.064057Z",
+    "prcs_init_by": "SCOTT",
+    "prcs_due_on": null,
+    "diagramsUsed": [
+        {
+            "diagramLevel": 0,
+            "diagramId": 146,
+            "diagramName": "Process Large Export Order",
+            "diagramVersion": "1",
+            "diagramStatus": "draft",
+            "callingDiagram": null,
+            "callingObject": null
+        },
+        {
+            "diagramLevel": 28602,
+            "diagramId": 147,
+            "diagramName": "Generate Export Paperwork",
+            "diagramVersion": "0",
+            "diagramStatus": "draft",
+            "callingDiagram": 146,
+            "callingObject": "Activity_1c61tqz"
+        }
+    ],
+    "events": [
+        {
+            "event": "created",
+            "diagram": 146,
+            "timestamp": "2022-12-02T06:40:12.077756Z",
+            "user": "SCOTT"
+        },
+        {
+            "event": "started",
+            "diagram": 146,
+            "timestamp": "2022-12-02T06:40:12.081617Z",
+            "user": "SCOTT"
+        },
+        {
+            "event": "start called model",
+            "object": "Activity_1c61tqz",
+            "diagram": 146,
+            "timestamp": "2022-12-02T06:46:48.849763Z",
+            "user": "FLOWSDEV2",
+            "comment": "Starting called diagram Generate Export Paperwork version ."
+        },
+        {
+            "event": "Gateway Processed",
+            "object": "Gateway_Inc_ShipModes",
+            "diagram": 146,
+            "timestamp": "2022-12-02T06:46:48.884936Z",
+            "user": "FLOWSDEV2",
+            "comment": "Chosen Paths : Flow_0rpxblp:Flow_1klmqrg"
+        },
+        {
+            "event": "finish called model",
+            "object": "Event_1b31018",
+            "diagram": 146,
+            "timestamp": "2022-12-02T06:50:56.915332Z",
+            "user": "ED",
+            "comment": "Leaving called diagram Generate Export Paperwork."
+        }
+    ],
+    "steps": [
+        {
+            "object": "Event_Start_Exco",
+            "subflowID": 28594,
+            "processLevel": 0,
+            "wasCurrent": "2022-12-02T06:40:12.109283Z",
+            "wasCompleted": "2022-12-02T06:40:12.134109Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "SCOTT"
+        },
+        {
+            "object": "Activity_Enter_Order",
+            "subflowID": 28594,
+            "processLevel": 0,
+            "lastCompleted": "Event_Start_Exco",
+            "wasCurrent": "2022-12-02T06:40:12.134384Z",
+            "wasCompleted": "2022-12-02T06:41:58.917589Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "reservation": "SCOTT",
+            "user": "SCOTT"
+        },
+        {
+            "object": "Activity_0o48cf3",
+            "subflowID": 28594,
+            "processLevel": 0,
+            "lastCompleted": "Activity_Enter_Order",
+            "wasCurrent": "2022-12-02T06:41:58.920577Z",
+            "wasCompleted": "2022-12-02T06:46:48.629197Z",
+            "statusWhenComplete": "waiting for approval",
+            "subflowDiagram": 146,
+            "user": "FLOWSDEV2"
+        },
+        {
+            "object": "Gateway_0iirqxr",
+            "subflowID": 28594,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_0iirqxr",
+            "wasCurrent": "2022-12-02T06:46:48.629356Z",
+            "wasCompleted": "2022-12-02T06:46:48.691172Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "FLOWSDEV2"
+        },
+        {
+            "object": "Gateway_0kh5iel",
+            "subflowID": 28594,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_0kh5iel",
+            "wasCurrent": "2022-12-02T06:46:48.691271Z",
+            "wasCompleted": "2022-12-02T06:52:15.460988Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "OSCAR"
+        },
+        {
+            "object": "Gateway_1vn4tgg",
+            "subflowID": 28594,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_1vn4tgg",
+            "wasCurrent": "2022-12-02T06:46:48.691271Z",
+            "wasCompleted": "2022-12-02T06:46:48.710226Z",
+            "statusWhenComplete": "split",
+            "subflowDiagram": 146,
+            "user": "FLOWSDEV2"
+        },
+        {
+            "object": "exportOrLocalDocGateway",
+            "subflowID": 28595,
+            "processLevel": 0,
+            "lastCompleted": "exportOrLocalDocGateway",
+            "wasCurrent": "2022-12-02T06:46:48.715093Z",
+            "wasCompleted": "2022-12-02T06:46:48.755546Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "FLOWSDEV2"
+        },
+        {
+            "object": "Activity_1ow2uze",
+            "subflowID": 28595,
+            "processLevel": 0,
+            "lastCompleted": "exportOrLocalDocGateway",
+            "wasCurrent": "2022-12-02T06:46:48.755617Z",
+            "wasCompleted": "2022-12-02T06:51:04.823364Z",
+            "statusWhenComplete": "in subprocess",
+            "subflowDiagram": 146,
+            "user": "ED"
+        },
+        {
+            "object": "Event_0n2zeza",
+            "subflowID": 28598,
+            "processLevel": 28598,
+            "lastCompleted": "exportOrLocalDocGateway",
+            "wasCurrent": "2022-12-02T06:46:48.781017Z",
+            "wasCompleted": "2022-12-02T06:46:48.817686Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "FLOWSDEV2"
+        },
+        {
+            "object": "Gateway_0r2ju5v",
+            "subflowID": 28598,
+            "processLevel": 28598,
+            "lastCompleted": "Gateway_0r2ju5v",
+            "wasCurrent": "2022-12-02T06:46:48.817763Z",
+            "wasCompleted": "2022-12-02T06:46:48.821453Z",
+            "statusWhenComplete": "split",
+            "subflowDiagram": 146,
+            "user": "FLOWSDEV2"
+        },
+        {
+            "object": "Activity_1c61tqz",
+            "subflowID": 28600,
+            "processLevel": 28598,
+            "lastCompleted": "Gateway_0r2ju5v",
+            "wasCurrent": "2022-12-02T06:46:48.822358Z",
+            "wasCompleted": "2022-12-02T06:50:56.916712Z",
+            "statusWhenComplete": "in call activity",
+            "subflowDiagram": 146,
+            "user": "ED"
+        },
+        {
+            "object": "Event_0g5ea9q",
+            "subflowID": 28602,
+            "processLevel": 28602,
+            "lastCompleted": "Activity_1c61tqz",
+            "wasCurrent": "2022-12-02T06:46:48.837998Z",
+            "wasCompleted": "2022-12-02T06:46:48.851562Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 147,
+            "user": "FLOWSDEV2"
+        },
+        {
+            "object": "Activity_17zccdb",
+            "subflowID": 28602,
+            "processLevel": 28602,
+            "lastCompleted": "Event_0g5ea9q",
+            "wasCurrent": "2022-12-02T06:46:48.851654Z",
+            "wasCompleted": "2022-12-02T06:47:45.913923Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 147,
+            "user": "ED"
+        },
+        {
+            "object": "Activity_1w0hgj6",
+            "subflowID": 28601,
+            "processLevel": 28598,
+            "lastCompleted": "Gateway_0r2ju5v",
+            "wasCurrent": "2022-12-02T06:46:48.853372Z",
+            "wasCompleted": "2022-12-02T06:51:04.732512Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "reservation": "ED",
+            "user": "ED"
+        },
+        {
+            "object": "Activity_1bum658",
+            "subflowID": 28596,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_1vn4tgg",
+            "wasCurrent": "2022-12-02T06:46:48.854688Z",
+            "wasStarted": "2022-12-02T06:46:48.859446Z",
+            "wasCompleted": "2022-12-02T06:46:48.869485Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "FLOWSDEV2"
+        },
+        {
+            "object": "Gateway_0vab9yd",
+            "subflowID": 28596,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_0vab9yd",
+            "wasCurrent": "2022-12-02T06:46:48.869599Z",
+            "wasCompleted": "2022-12-02T06:52:15.453755Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "OSCAR"
+        },
+        {
+            "object": "Gateway_Inc_ShipModes",
+            "subflowID": 28596,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_Inc_ShipModes",
+            "wasCurrent": "2022-12-02T06:46:48.869599Z",
+            "wasCompleted": "2022-12-02T06:46:48.888668Z",
+            "statusWhenComplete": "split",
+            "subflowDiagram": 146,
+            "user": "FLOWSDEV2"
+        },
+        {
+            "object": "Activity_1cozv1y",
+            "subflowID": 28603,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_Inc_ShipModes",
+            "wasCurrent": "2022-12-02T06:46:48.889639Z",
+            "wasCompleted": "2022-12-02T06:52:11.614937Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "reservation": "OSCAR",
+            "user": "OSCAR"
+        },
+        {
+            "object": "Activity_1dewv3m",
+            "subflowID": 28604,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_Inc_ShipModes",
+            "wasCurrent": "2022-12-02T06:46:48.890973Z",
+            "wasCompleted": "2022-12-02T06:52:15.391963Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "reservation": "OSCAR",
+            "user": "OSCAR"
+        },
+        {
+            "object": "Activity_1fh9sk7",
+            "subflowID": 28597,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_1vn4tgg",
+            "wasCurrent": "2022-12-02T06:46:48.892273Z",
+            "wasStarted": "2022-12-02T06:46:48.892680Z",
+            "wasCompleted": "2022-12-02T06:46:48.897479Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "FLOWSDEV2"
+        },
+        {
+            "object": "Activity_148qqch",
+            "subflowID": 28602,
+            "processLevel": 28602,
+            "lastCompleted": "Activity_17zccdb",
+            "wasCurrent": "2022-12-02T06:47:45.914129Z",
+            "wasCompleted": "2022-12-02T06:50:56.889983Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 147,
+            "user": "ED"
+        },
+        {
+            "object": "Event_1b31018",
+            "subflowID": 28602,
+            "processLevel": 28602,
+            "lastCompleted": "Event_1b31018",
+            "wasCurrent": "2022-12-02T06:50:56.890183Z",
+            "wasCompleted": "2022-12-02T06:50:56.896863Z",
+            "statusWhenComplete": "completed",
+            "subflowDiagram": 147,
+            "user": "ED"
+        },
+        {
+            "object": "Event_0ctcxyt",
+            "subflowID": 28600,
+            "processLevel": 28598,
+            "lastCompleted": "Event_0ctcxyt",
+            "wasCurrent": "2022-12-02T06:50:56.916807Z",
+            "wasCompleted": "2022-12-02T06:50:56.917424Z",
+            "statusWhenComplete": "completed",
+            "subflowDiagram": 146,
+            "user": "ED"
+        },
+        {
+            "object": "Event_1q5elwj",
+            "subflowID": 28601,
+            "processLevel": 28598,
+            "lastCompleted": "Event_1q5elwj",
+            "wasCurrent": "2022-12-02T06:51:04.733043Z",
+            "wasCompleted": "2022-12-02T06:51:04.734648Z",
+            "statusWhenComplete": "completed",
+            "subflowDiagram": 146,
+            "user": "ED"
+        },
+        {
+            "object": "Gateway_1qon03h",
+            "subflowID": 28595,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_1qon03h",
+            "wasCurrent": "2022-12-02T06:51:04.823475Z",
+            "wasCompleted": "2022-12-02T06:51:04.825890Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "ED"
+        },
+        {
+            "object": "Activity_13ozi9d",
+            "subflowID": 28596,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_0vab9yd",
+            "wasCurrent": "2022-12-02T06:52:15.453892Z",
+            "wasStarted": "2022-12-02T06:52:15.454674Z",
+            "wasCompleted": "2022-12-02T06:52:15.457631Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "OSCAR"
+        },
+        {
+            "object": "Activity_0pozgkx",
+            "subflowID": 28594,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_0kh5iel",
+            "wasCurrent": "2022-12-02T06:52:15.461057Z",
+            "wasCompleted": "2022-12-02T06:52:53.002704Z",
+            "statusWhenComplete": "waiting for approval",
+            "subflowDiagram": 146,
+            "user": "SCOTT"
+        },
+        {
+            "object": "Activity_1voltm6",
+            "subflowID": 28594,
+            "processLevel": 0,
+            "lastCompleted": "Activity_0pozgkx",
+            "wasCurrent": "2022-12-02T06:52:53.002961Z",
+            "wasCompleted": "2022-12-02T07:04:21.418268Z",
+            "statusWhenComplete": "waiting for approval",
+            "subflowDiagram": 146,
+            "user": "GEORGIA"
+        },
+        {
+            "object": "Activity_1oqds9y",
+            "subflowID": 28594,
+            "processLevel": 0,
+            "lastCompleted": "Activity_1voltm6",
+            "wasCurrent": "2022-12-02T07:04:21.418468Z",
+            "wasCompleted": "2022-12-02T07:04:44.757669Z",
+            "statusWhenComplete": "waiting for approval",
+            "subflowDiagram": 146,
+            "user": "ED"
+        },
+        {
+            "object": "Gateway_13czvao",
+            "subflowID": 28594,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_13czvao",
+            "wasCurrent": "2022-12-02T07:04:44.757856Z",
+            "wasCompleted": "2022-12-02T07:04:44.763307Z",
+            "statusWhenComplete": "split",
+            "subflowDiagram": 146,
+            "user": "ED"
+        },
+        {
+            "object": "Activity_18ugqjq",
+            "subflowID": 28605,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_13czvao",
+            "wasCurrent": "2022-12-02T07:04:44.764387Z",
+            "wasStarted": "2022-12-02T07:04:44.765036Z",
+            "wasCompleted": "2022-12-02T07:04:44.767660Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "ED"
+        },
+        {
+            "object": "Event_1t06ziv",
+            "subflowID": 28605,
+            "processLevel": 0,
+            "lastCompleted": "Event_1t06ziv",
+            "wasCurrent": "2022-12-02T07:04:44.767726Z",
+            "wasCompleted": "2022-12-02T07:04:44.768416Z",
+            "statusWhenComplete": "completed",
+            "subflowDiagram": 146,
+            "user": "ED"
+        },
+        {
+            "object": "Activity_0etzv1y",
+            "subflowID": 28606,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_13czvao",
+            "wasCurrent": "2022-12-02T07:04:44.773611Z",
+            "wasCompleted": "2022-12-02T07:05:14.799920Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "reservation": "OSCAR",
+            "user": "OSCAR"
+        },
+        {
+            "object": "exportOrLocalPackingGateway",
+            "subflowID": 28606,
+            "processLevel": 0,
+            "lastCompleted": "exportOrLocalPackingGateway",
+            "wasCurrent": "2022-12-02T07:05:14.800399Z",
+            "wasCompleted": "2022-12-02T07:05:14.865181Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "OSCAR"
+        },
+        {
+            "object": "Activity_1ll5xmd",
+            "subflowID": 28606,
+            "processLevel": 0,
+            "lastCompleted": "exportOrLocalPackingGateway",
+            "wasCurrent": "2022-12-02T07:05:14.865275Z",
+            "wasCompleted": "2022-12-02T07:05:28.186753Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "reservation": "OSCAR",
+            "user": "OSCAR"
+        },
+        {
+            "object": "Event_1nncfer",
+            "subflowID": 28606,
+            "processLevel": 0,
+            "lastCompleted": "Activity_1ll5xmd",
+            "wasCurrent": "2022-12-02T07:05:28.187215Z",
+            "wasCompleted": "2022-12-02T07:05:57.305622Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "FLOWSDEV2"
+        },
+        {
+            "object": "Gateway_1gk5qxz",
+            "subflowID": 28606,
+            "processLevel": 0,
+            "lastCompleted": "Gateway_1gk5qxz",
+            "wasCurrent": "2022-12-02T07:05:57.305845Z",
+            "wasCompleted": "2022-12-02T07:05:57.339609Z",
+            "statusWhenComplete": "running",
+            "subflowDiagram": 146,
+            "user": "FLOWSDEV2"
+        }
+    ],
+    "processVariablesSet": [
+        {
+            "scope": 0,
+            "variables": [
+                {
+                    "var_name": "PROCESS_NAME",
+                    "subflowID": null,
+                    "objectId": null,
+                    "expr_set": null,
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T06:40:12.316907Z",
+                    "newValue": "Export Parts Order - BA A320 Seating Refurb G994K"
+                },
+                {
+                    "var_name": "BUSINESS_REF",
+                    "subflowID": null,
+                    "objectId": null,
+                    "expr_set": null,
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T06:40:15.389242Z",
+                    "newValue": "1006"
+                },
+                {
+                    "var_name": "Activity_0o48cf3:task_id",
+                    "subflowID": 28594,
+                    "objectId": "Activity_0o48cf3",
+                    "expr_set": null,
+                    "type": "NUMBER",
+                    "timestamp": "2022-12-02T06:41:58.938163Z",
+                    "newValue": "8280764444326998"
+                },
+                {
+                    "var_name": "OrderAccepted",
+                    "subflowID": 28594,
+                    "objectId": "Activity_0o48cf3",
+                    "expr_set": null,
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T06:46:48.627159Z",
+                    "newValue": "APPROVED"
+                },
+                {
+                    "var_name": "export_doc_reqd",
+                    "subflowID": 28595,
+                    "objectId": "exportOrLocalDocGateway",
+                    "expr_set": "beforeSplit",
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T06:46:48.751462Z",
+                    "newValue": "GLOBAL"
+                },
+                {
+                    "var_name": "Event_Export_Rem:applicationId",
+                    "subflowID": 28599,
+                    "objectId": "Event_Export_Rem",
+                    "expr_set": null,
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T06:46:48.799546Z",
+                    "newValue": "105"
+                },
+                {
+                    "var_name": "Event_Export_Rem:pageId",
+                    "subflowID": 28599,
+                    "objectId": "Event_Export_Rem",
+                    "expr_set": null,
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T06:46:48.799678Z",
+                    "newValue": "1"
+                },
+                {
+                    "var_name": "Event_Export_Rem:username",
+                    "subflowID": 28599,
+                    "objectId": "Event_Export_Rem",
+                    "expr_set": null,
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T06:46:48.799765Z",
+                    "newValue": "FLOWSDEV2"
+                },
+                {
+                    "var_name": "Ship_Modes",
+                    "subflowID": 28596,
+                    "objectId": "Gateway_Inc_ShipModes",
+                    "expr_set": "beforeSplit",
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T06:46:48.877980Z",
+                    "newValue": "courier:ocean"
+                },
+                {
+                    "var_name": "Activity_0pozgkx:task_id",
+                    "subflowID": 28594,
+                    "objectId": "Activity_0pozgkx",
+                    "expr_set": null,
+                    "type": "NUMBER",
+                    "timestamp": "2022-12-02T06:52:15.469908Z",
+                    "newValue": "8281813846388651"
+                },
+                {
+                    "var_name": "SHIP_APPROVAL_SALES",
+                    "subflowID": 28594,
+                    "objectId": "Activity_0pozgkx",
+                    "expr_set": null,
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T06:52:53.001015Z",
+                    "newValue": "APPROVED"
+                },
+                {
+                    "var_name": "Activity_1voltm6:task_id",
+                    "subflowID": 28594,
+                    "objectId": "Activity_1voltm6",
+                    "expr_set": null,
+                    "type": "NUMBER",
+                    "timestamp": "2022-12-02T06:52:53.009415Z",
+                    "newValue": "8281932362392405"
+                },
+                {
+                    "var_name": "SHIP_APPROVAL_GM",
+                    "subflowID": 28594,
+                    "objectId": "Activity_1voltm6",
+                    "expr_set": null,
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T07:04:21.416260Z",
+                    "newValue": "APPROVED"
+                },
+                {
+                    "var_name": "Activity_1oqds9y:task_id",
+                    "subflowID": 28594,
+                    "objectId": "Activity_1oqds9y",
+                    "expr_set": null,
+                    "type": "NUMBER",
+                    "timestamp": "2022-12-02T07:04:21.425889Z",
+                    "newValue": "8282061756461247"
+                },
+                {
+                    "var_name": "SHIP_APPROVAL_EXPORT",
+                    "subflowID": 28594,
+                    "objectId": "Activity_1oqds9y",
+                    "expr_set": null,
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T07:04:44.713193Z",
+                    "newValue": "APPROVED"
+                },
+                {
+                    "var_name": "PackagingType",
+                    "subflowID": 28606,
+                    "objectId": "exportOrLocalPackingGateway",
+                    "expr_set": "beforeSplit",
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T07:05:14.814047Z",
+                    "newValue": "export"
+                },
+                {
+                    "var_name": "Event_1nncfer:applicationId",
+                    "subflowID": 28606,
+                    "objectId": "Event_1nncfer",
+                    "expr_set": null,
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T07:05:28.190011Z",
+                    "newValue": "105"
+                },
+                {
+                    "var_name": "Event_1nncfer:pageId",
+                    "subflowID": 28606,
+                    "objectId": "Event_1nncfer",
+                    "expr_set": null,
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T07:05:28.190247Z",
+                    "newValue": "1"
+                },
+                {
+                    "var_name": "Event_1nncfer:username",
+                    "subflowID": 28606,
+                    "objectId": "Event_1nncfer",
+                    "expr_set": null,
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T07:05:28.190338Z",
+                    "newValue": "FLOWSDEV2"
+                }
+            ]
+        },
+        {
+            "scope": 28602,
+            "variables": [
+                {
+                    "var_name": "BUSINESS_REF",
+                    "subflowID": 28602,
+                    "objectId": "Activity_1c61tqz",
+                    "expr_set": "inVariables",
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T06:46:48.844361Z",
+                    "newValue": "1006"
+                },
+                {
+                    "var_name": "PROCESS_NAME",
+                    "subflowID": 28602,
+                    "objectId": "Activity_1c61tqz",
+                    "expr_set": "inVariables",
+                    "type": "VARCHAR2",
+                    "timestamp": "2022-12-02T06:46:48.844623Z",
+                    "newValue": "Export Doc Generator"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
-  adds extra columns to some log tables
- gathers daily, month-to-date, monthly & quarterly performance stats for instances and steps
- provides a purge mechanism for these statistics
- creates a JSON document summary of a process instance
- provides a mechanism to create and archive these summaries for all unarchived instances, with storage in database or OCI Object Storage
- creates a purge mechanism for log tables
- creates an instance timeline view to allow UI to display all instance events on a timeline