### PR TITLE
fix #576 - limit scheduler wakeups

### DIFF
--- a/setup/DBMS_SCHEDULER_setup_for_timers.txt
+++ b/setup/DBMS_SCHEDULER_setup_for_timers.txt
@@ -18,6 +18,13 @@ END;
 
 -------------
 -- RUN JOB
+-- See Documentation at url https://flowsforapex.org/latest/about-timer-execution/
+-- For Production Jobs, decide on your required frequency.  No more often than 'FREQ=SECONDLY;INTERVAL=10'
+
+-- For Demo Environments/ POC / sample apps:
+-- For Oracle shared environments apex.oracle.com and apex.oraclecorp.com, minimum interval is once per minute
+-- Please use the Flows for APEX Application to Disable timers if you are not going to be using your demo environment
+-- for several days.
 -------------
 BEGIN
 DBMS_SCHEDULER.create_job (
@@ -25,7 +32,7 @@ DBMS_SCHEDULER.create_job (
     program_name    => 'APEX_FLOW_STEP_TIMERS_P',
     job_style       => 'LIGHTWEIGHT',
     start_date      => SYSTIMESTAMP,
-    repeat_interval => 'FREQ=SECONDLY;INTERVAL=10',
+    repeat_interval => 'FREQ=MINUTELY;INTERVAL=5',
     enabled         => TRUE
 );
 

--- a/src/data/install_engine_messages_en.sql
+++ b/src/data/install_engine_messages_en.sql
@@ -235,6 +235,8 @@ begin
     values ( 'archive-destination-bad-json', c_load_lang, q'[Error in archive destination configuration parameter.  Parameter: %0]' ); 
   insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
     values ( 'log-archive-error', c_load_lang, q'[Error archiving instance summary for Process Instance %0]' ); 
+  insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+    values ( 'scheduler-repeat-shared-env', c_load_lang, q'[Timer repeat interval too frequent for host (%0) Requested Interval %1.  Must be greater than 1 Minute.]' ); 
 
 
   commit;

--- a/src/plsql/engine-app/flow_engine_app_api.pkb
+++ b/src/plsql/engine-app/flow_engine_app_api.pkb
@@ -109,6 +109,8 @@ as
       case upper(apex_application.g_x01)
         when 'RESET-FLOW-INSTANCE' then
           flow_api_pkg.flow_reset( p_process_id => apex_application.g_x02, p_comment => apex_application.g_x03 );
+        when 'STEP-TIMERS' then
+          flow_api_pkg.step_timers;
         when 'START-FLOW-INSTANCE' then
           flow_api_pkg.flow_start( p_process_id => apex_application.g_x02 );
         when 'DELETE-FLOW-INSTANCE' then
@@ -1492,6 +1494,8 @@ as
   , pi_default_pageid            in flow_configuration.cfig_value%type
   , pi_default_username          in flow_configuration.cfig_value%type
   , pi_timer_max_cycles          in flow_configuration.cfig_value%type
+  , pi_timer_status              in sys.all_scheduler_jobs.enabled%type
+  , pi_timer_repeat_interval     in sys.all_scheduler_jobs.repeat_interval%type
   )
   as
   begin
@@ -1506,6 +1510,14 @@ as
       flow_engine_util.set_config_value( p_config_key => flow_constants_pkg.gc_config_default_pageid      , p_value => pi_default_pageid);
       flow_engine_util.set_config_value( p_config_key => flow_constants_pkg.gc_config_default_username    , p_value => pi_default_username);
       flow_engine_util.set_config_value( p_config_key => flow_constants_pkg.gc_config_timer_max_cycles    , p_value => pi_timer_max_cycles);
+
+      case pi_timer_status
+      when 'TRUE'  then flow_timers_pkg.enable_scheduled_job;
+      when 'FALSE' then flow_timers_pkg.disable_scheduled_job;
+      end case;
+
+      flow_timers_pkg.set_timer_repeat_interval( p_repeat_interval => pi_timer_repeat_interval);
+
   end set_settings;
 
 

--- a/src/plsql/engine-app/flow_engine_app_api.pks
+++ b/src/plsql/engine-app/flow_engine_app_api.pks
@@ -216,6 +216,8 @@ as
   , pi_default_pageid            in flow_configuration.cfig_value%type
   , pi_default_username          in flow_configuration.cfig_value%type
   , pi_timer_max_cycles          in flow_configuration.cfig_value%type
+  , pi_timer_status              in sys.all_scheduler_jobs.enabled%type
+  , pi_timer_repeat_interval     in sys.all_scheduler_jobs.repeat_interval%type
   );
 
   /* page 11 */

--- a/src/plsql/flow_admin_api.pks
+++ b/src/plsql/flow_admin_api.pks
@@ -30,7 +30,7 @@ The `flow_admin_api` package gives you access to the Flows for APEX engine admin
   procedure purge_instance_logs
   ( p_retention_period_days  in number default null
   );
-  
+
 -- Performance Summary Functions
 
   procedure run_daily_stats;

--- a/src/plsql/flow_api_pkg.pkb
+++ b/src/plsql/flow_api_pkg.pkb
@@ -455,5 +455,13 @@ create or replace package body flow_api_pkg as
            );
   end intervalDStoSec;
 
+-- Manually Step Forward Timers
+
+  procedure step_timers
+  is
+  begin
+    flow_timers_pkg.step_timers;
+  end;
+
 end flow_api_pkg;
 /

--- a/src/plsql/flow_api_pkg.pks
+++ b/src/plsql/flow_api_pkg.pks
@@ -581,5 +581,11 @@ flow_api_pkg.return_approval_result ( p_process_id      => :PROCESS_ID,
     p_intervalDS  interval day to second
   ) return number;
 
+
+-- Manually Step Timers forward
+
+  procedure step_timers;
+
+
 end flow_api_pkg;
 /

--- a/src/plsql/flow_constants_pkg.pks
+++ b/src/plsql/flow_constants_pkg.pks
@@ -1,13 +1,13 @@
+create or replace package flow_constants_pkg
 /* 
 -- Flows for APEX - flow_constants_pkg.pks
 -- 
--- (c) Copyright Oracle Corporation and / or its affiliates. 2022.
+-- (c) Copyright Oracle Corporation and / or its affiliates. 2022-23.
 --
 -- Created 2020   Moritz Klein - MT AG  
 -- Edited  14-Mar-2022 R Allen, Oracle
 --
 */
-create or replace package flow_constants_pkg
   authid definer
 as
 

--- a/src/plsql/flow_timers_pkg.pks
+++ b/src/plsql/flow_timers_pkg.pks
@@ -1,14 +1,26 @@
 create or replace package flow_timers_pkg
-  authid definer
--- accessible by ( flow_engine, flow_instances, flow_boundary_events, flow_api_pkg )
-as
-/******************************************************************************
- Purpose:
+/* 
+-- Flows for APEX - flow_timers_pkg.pks
+-- 
+-- (c) Copyright Oracle Corporation and / or its affiliates. 2022-23.
+--
+-- Created 2020        Franco Soldaro
+-- Edited  2020        Moritz Klein - MT AG  
+-- Edited  24-Feb-2023 Richard Allen, Oracle
+--
+Purpose:
    Provides support to timers in Flows for APEX.
 
  Grants required:
    CREATE JOB
+
+
 ******************************************************************************/
+  authid definer
+-- accessible by ( flow_engine, flow_instances, flow_boundary_events, flow_api_pkg
+--               , flow_admin_api )
+as
+
 
 /******************************************************************************
   CONSTANTS
@@ -141,6 +153,31 @@ procedure reschedule_timer
     po_return_code  out  number
   );
 
+
+/******************************************************************************
+  get_timer_repeat_interval
+    get the repeat interval of the timer scheduler job.
+******************************************************************************/
+  function get_timer_repeat_interval
+  return sys.all_scheduler_jobs.repeat_interval%type
+  ;
+
+/******************************************************************************
+  set_timer_repeat_interval
+    set the repeat interval of the timer scheduler job (uses dbms_scheduler syntax)
+******************************************************************************/
+
+  procedure set_timer_repeat_interval 
+  ( p_repeat_interval  in  varchar2
+  );
+
+/******************************************************************************
+  get_timer_status
+    disable the scheduled job processing of timers.
+******************************************************************************/
+
+  function get_timer_status
+  return varchar2;
 
 /******************************************************************************
   disable_scheduled_job


### PR DESCRIPTION
- sets default timer wake-up to 5 minutes for new installations
- exposes step_timers through flow_api_pkg for manual timer stepping
- allows scheduler status to be got
- allows scheduler repeat interval to be set
- restricts installations on apex.oracle.com and apex.oraclecorp.com shared servers to have repeat_interval < 1 minute