### PR TITLE
#325 Features/diagram logging

### DIFF
--- a/bpmn_examples/sql/FlowsforAPEX-V5-full-syntax.sql
+++ b/bpmn_examples/sql/FlowsforAPEX-V5-full-syntax.sql
@@ -1159,7 +1159,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'V5FullSyntax',
     pi_dgrm_version => '0',
     pi_dgrm_category => 'My demos',

--- a/bpmn_tutorials/sql/Tutorial 1  - Getting Started_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 1  - Getting Started_22.2.sql
@@ -181,7 +181,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 1  - Getting Started',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 2a - Basic Navigation with Gateways_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 2a - Basic Navigation with Gateways_22.2.sql
@@ -400,7 +400,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 2a - Basic Navigation with Gateways',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 2b - Parallel Gateways_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 2b - Parallel Gateways_22.2.sql
@@ -429,7 +429,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 2b - Parallel Gateways',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 2c - Inclusive Gateways_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 2c - Inclusive Gateways_22.2.sql
@@ -396,7 +396,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 2c - Inclusive Gateways',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 2d - Making your process pause_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 2d - Making your process pause_22.2.sql
@@ -396,7 +396,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 2d - Making your process pause',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 3a - Setting Process Variables from your Model_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 3a - Setting Process Variables from your Model_22.2.sql
@@ -603,7 +603,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 3a - Setting Process Variables from your Model',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 3b - Substitution and Bind Syntax_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 3b - Substitution and Bind Syntax_22.2.sql
@@ -482,7 +482,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 3b - Substitution and Bind Syntax',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 4a - Tasks Get Your Work Done!_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 4a - Tasks Get Your Work Done!_22.2.sql
@@ -218,7 +218,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 4a - Tasks Get Your Work Done!',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 4b - Reminders and Timeouts_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 4b - Reminders and Timeouts_22.2.sql
@@ -291,7 +291,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 4b - Reminders and Timeouts',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 5a - Structure your Process with Sub Processes and Calls_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 5a - Structure your Process with Sub Processes and Calls_22.2.sql
@@ -286,7 +286,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 5a - Structure your Process with Sub Processes and Calls',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 5b - Introducing Sub Processes_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 5b - Introducing Sub Processes_22.2.sql
@@ -273,7 +273,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 5b - Introducing Sub Processes',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 5c - Handling Sub Process Error and Escalation Events_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 5c - Handling Sub Process Error and Escalation Events_22.2.sql
@@ -463,7 +463,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 5c - Handling Sub Process Error and Escalation Events',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 5d - Using CallActivities to call another diagram_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 5d - Using CallActivities to call another diagram_22.2.sql
@@ -397,7 +397,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 5d - Using CallActivities to call another diagram',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 5e - ship Goods (Called by Tutorial 5d)_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 5e - ship Goods (Called by Tutorial 5d)_22.2.sql
@@ -281,7 +281,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 5e - ship Goods (Called by Tutorial 5d)',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 5f - Making a Diagram Callable_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 5f - Making a Diagram Callable_22.2.sql
@@ -127,7 +127,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 5f - Making a Diagram Callable',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 6a - Collaborations, Lanes and Reservations_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 6a - Collaborations, Lanes and Reservations_22.2.sql
@@ -426,7 +426,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 6a - Collaborations, Lanes and Reservations',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 8a - The Full Monty (the top half!)_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 8a - The Full Monty (the top half!)_22.2.sql
@@ -1376,7 +1376,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 8a - The Full Monty (the top half!)',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/bpmn_tutorials/sql/Tutorial 8c - Background Session Configuration_22.2.sql
+++ b/bpmn_tutorials/sql/Tutorial 8c - Background Session Configuration_22.2.sql
@@ -302,7 +302,7 @@ begin
       ,q'[</bpmn:definitions>]'
       ,q'[]'
   ));
-  flow_bpmn_parser_pkg.upload_and_parse(
+  flow_diagram.upload_and_parse(
     pi_dgrm_name => 'Tutorial 8c - Background Session Configuration',
     pi_dgrm_version => '22.2',
     pi_dgrm_category => 'Tutorials',

--- a/src/common_db.sql
+++ b/src/common_db.sql
@@ -55,6 +55,7 @@ PROMPT >> Installing Views
 @views/flow_diagrams_vw.sql
 @views/flow_instance_diagrams_lov.sql
 @views/flow_diagrams_instanciated_lov.sql
+@views/flow_instance_timeline_vw.sql
 
 PROMPT >> Installing Package Bodies
 @plsql/flow_proc_vars_int.pkb
@@ -124,6 +125,8 @@ PROMPT >> Page Views
 @views/engine-app/flow_p0014_step_log_vw.sql
 @views/engine-app/flow_p0014_subflows_vw.sql
 @views/engine-app/flow_p0014_variable_log_vw.sql
+@views/engine-app/flow_p0020_instance_timeline_vw.sql
+
 
 PROMPT >> Global App Package Body
 @plsql/engine-app/flow_engine_app_api.pkb

--- a/src/data/install_engine_messages_en.sql
+++ b/src/data/install_engine_messages_en.sql
@@ -245,6 +245,8 @@ begin
     values ( 'msgflow-lock-timeout-msub', c_load_lang, q'[Message Subscription locked by another user.   Try again.]' ); 
   insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
     values ( 'msgflow-lock-timeout-subflow', c_load_lang, q'[Message receiver unable to lock subflow.  Try again.]' ); 
+  insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+    values ( 'logging-diagram-event', c_load_lang, q'[Flows - Internal error while logging a Diagram Event.]' ); 
 
 
   commit;

--- a/src/ddl/install_scratch.sql
+++ b/src/ddl/install_scratch.sql
@@ -436,15 +436,15 @@ ALTER TABLE flow_object_expressions
 /* Event logging Tables */
 
 create table flow_flow_event_log
-( lgfl_dgrm_id       		NUMBER NOT NULL
-, lgfl_dgrm_name     		VARCHAR2(150 CHAR) NOT NULL
-, lgfl_dgrm_version  		VARCHAR2(10 CHAR) NOT NULL
-, lgfl_dgrm_status   		VARCHAR2(10 CHAR) NOT NULL
-, lgfl_dgrm_category 		VARCHAR2(30 CHAR)
-, lgfl_timestamp 			TIMESTAMP WITH TIME ZONE NOT NULL
-, lgfl_user				    VARCHAR2(255 char)
-, lgfl_comment              VARCHAR2(2000 CHAR)
-, lgfl_dgrm_content  		CLOB
+( lgfl_dgrm_id       		    NUMBER NOT NULL
+, lgfl_dgrm_name     		    VARCHAR2(150 CHAR)
+, lgfl_dgrm_version  		    VARCHAR2(10 CHAR) 
+, lgfl_dgrm_status   		    VARCHAR2(10 CHAR) 
+, lgfl_dgrm_category 		    VARCHAR2(30 CHAR)
+, lgfl_timestamp 			    TIMESTAMP WITH TIME ZONE NOT NULL
+, lgfl_user				        VARCHAR2(255 char)
+, lgfl_comment                  VARCHAR2(2000 CHAR)
+, lgfl_dgrm_archive_location    VARCHAR2(2000 CHAR)
 );
 
 create table flow_instance_event_log

--- a/src/migrations/22.2_to_23.1/feature-325.sql
+++ b/src/migrations/22.2_to_23.1/feature-325.sql
@@ -64,3 +64,19 @@ alter table flow_stats_type
   insert into flow_configuration (cfig_key, cfig_value) values ('stats_retain_daily_summaries_days','185');
   insert into flow_configuration (cfig_key, cfig_value) values ('stats_retain_monthly_summaries_months','9');
   insert into flow_configuration (cfig_key, cfig_value) values ('stats_retain_quarterly_summaries_months','60');
+
+-- modify flow_flow_event_log
+
+  alter table flow_flow_event_log 
+    drop column lgfl_dgrm_content;
+
+  alter table flow_flow_event_log
+    add ( lgfl_dgrm_archive_location  varchar2(2000));
+
+  alter table flow_flow_event_log
+    modify 
+    ( lgfl_dgrm_name null
+    , lgfl_dgrm_status null
+    , lgfl_dgrm_version null
+    );
+    

--- a/src/plsql/engine-app/flow_engine_app_api.pkb
+++ b/src/plsql/engine-app/flow_engine_app_api.pkb
@@ -831,7 +831,7 @@ as
     end loop;
     l_buffer := '  ));';
     l_buffer := l_buffer||utl_tcp.crlf;
-    l_buffer := l_buffer||'  flow_bpmn_parser_pkg.upload_and_parse('||utl_tcp.crlf;
+    l_buffer := l_buffer||'  flow_diagram.upload_and_parse('||utl_tcp.crlf;
     l_buffer := l_buffer||'    pi_dgrm_name => '||dbms_assert.enquote_literal(r_diagrams.dgrm_name)||','||utl_tcp.crlf;
     l_buffer := l_buffer||'    pi_dgrm_version => '||dbms_assert.enquote_literal(r_diagrams.dgrm_version)||','||utl_tcp.crlf;
     l_buffer := l_buffer||'    pi_dgrm_category => '||dbms_assert.enquote_literal(r_diagrams.dgrm_category)||','||utl_tcp.crlf;

--- a/src/plsql/flow_constants_pkg.pks
+++ b/src/plsql/flow_constants_pkg.pks
@@ -300,6 +300,7 @@ as
   gc_config_logging_archive_enabled     constant varchar2(50 char) := 'logging_archive_instance_summaries';
   gc_config_logging_message_flow_recd   constant varchar2(50 char) := 'logging_received_message_flow';
   gc_config_logging_retain_msg_flow     constant varchar2(50 char) := 'logging_retain_message_flow_days';
+  gc_config_logging_bpmn_location       constant varchar2(50 char) := 'logging_bpmn_location';
   gc_config_engine_app_mode             constant varchar2(50 char) := 'engine_app_mode';
   gc_config_dup_step_prevention         constant varchar2(50 char) := 'duplicate_step_prevention';
   gc_config_timer_max_cycles            constant varchar2(50 char) := 'timer_max_cycles';
@@ -356,7 +357,10 @@ as
   gc_stats_outcome_success              constant varchar2(50 char) := 'SUCCESS';
   gc_stats_outcome_error                constant varchar2(50 char) := 'ERROR';
 
+-- MIME types
 
+  gc_mime_type_bpmn                     constant varchar2(50 char) := 'application/bpmn-xml';
+  gc_mime_type_json                     constant varchar2(50 char) := 'application/json';
 
   -- Default XML for new diagrams
   gc_default_xml constant varchar2(4000) := '<?xml version="1.0" encoding="UTF-8"?>

--- a/src/plsql/flow_diagram.pks
+++ b/src/plsql/flow_diagram.pks
@@ -1,11 +1,12 @@
 /* 
 -- Flows for APEX - flow_diagram.pks
 -- 
--- (c) Copyright Oracle Corporation and / or its affiliates, 2022.
+-- (c) Copyright Oracle Corporation and / or its affiliates, 2022-23.
 -- (c) Copyright MT AG, 2021-2022.
 --
 -- Created  10-Dec-2021  Dennis Amthor - MT AG
 -- Modified 22-May-2022  Moritz Klein - MT AG
+-- Modified 16-Mar-2023  Richard Allen - Oracle 
 --
 */
 create or replace package flow_diagram
@@ -23,7 +24,42 @@ as
     pi_dgrm_version in flow_diagrams.dgrm_version%type)
   return flow_diagrams.dgrm_id%type;
 
+  function upload_diagram
+  (
+    pi_dgrm_name       in flow_diagrams.dgrm_name%type
+  , pi_dgrm_version    in flow_diagrams.dgrm_version%type
+  , pi_dgrm_category   in flow_diagrams.dgrm_category%type
+  , pi_dgrm_content    in flow_diagrams.dgrm_content%type
+  , pi_dgrm_status     in flow_diagrams.dgrm_status%type default flow_constants_pkg.gc_dgrm_status_draft
+  , pi_force_overwrite in boolean default false
+  ) return flow_diagrams.dgrm_id%type;
 
+  procedure upload_diagram
+  (
+    pi_dgrm_name     in flow_diagrams.dgrm_name%type
+  , pi_dgrm_version  in flow_diagrams.dgrm_version%type
+  , pi_dgrm_category in flow_diagrams.dgrm_category%type
+  , pi_dgrm_content  in flow_diagrams.dgrm_content%type
+  , pi_dgrm_status   in flow_diagrams.dgrm_status%type default flow_constants_pkg.gc_dgrm_status_draft
+  , pi_force_overwrite in boolean default false
+  );
+
+  procedure upload_and_parse
+  (
+    pi_dgrm_name     in flow_diagrams.dgrm_name%type
+  , pi_dgrm_version  in flow_diagrams.dgrm_version%type
+  , pi_dgrm_category in flow_diagrams.dgrm_category%type
+  , pi_dgrm_content  in flow_diagrams.dgrm_content%type
+  , pi_dgrm_status   in flow_diagrams.dgrm_status%type default flow_constants_pkg.gc_dgrm_status_draft
+  , pi_force_overwrite in boolean default false
+  );
+
+  procedure update_diagram
+  (
+    pi_dgrm_id      in flow_diagrams.dgrm_id%type
+  , pi_dgrm_content in flow_diagrams.dgrm_content%type
+  );
+  
   function add_diagram_version(
     pi_dgrm_id in flow_diagrams.dgrm_id%type,
     pi_dgrm_version in flow_diagrams.dgrm_version%type)

--- a/src/plsql/flow_diagram.pks
+++ b/src/plsql/flow_diagram.pks
@@ -31,26 +31,29 @@ as
   , pi_dgrm_category   in flow_diagrams.dgrm_category%type
   , pi_dgrm_content    in flow_diagrams.dgrm_content%type
   , pi_dgrm_status     in flow_diagrams.dgrm_status%type default flow_constants_pkg.gc_dgrm_status_draft
+  , pi_log_comment     in flow_flow_event_log.lgfl_comment%type default null
   , pi_force_overwrite in boolean default false
   ) return flow_diagrams.dgrm_id%type;
 
   procedure upload_diagram
   (
-    pi_dgrm_name     in flow_diagrams.dgrm_name%type
-  , pi_dgrm_version  in flow_diagrams.dgrm_version%type
-  , pi_dgrm_category in flow_diagrams.dgrm_category%type
-  , pi_dgrm_content  in flow_diagrams.dgrm_content%type
-  , pi_dgrm_status   in flow_diagrams.dgrm_status%type default flow_constants_pkg.gc_dgrm_status_draft
+    pi_dgrm_name       in flow_diagrams.dgrm_name%type
+  , pi_dgrm_version    in flow_diagrams.dgrm_version%type
+  , pi_dgrm_category   in flow_diagrams.dgrm_category%type
+  , pi_dgrm_content    in flow_diagrams.dgrm_content%type
+  , pi_dgrm_status     in flow_diagrams.dgrm_status%type default flow_constants_pkg.gc_dgrm_status_draft
+  , pi_log_comment     in flow_flow_event_log.lgfl_comment%type default null
   , pi_force_overwrite in boolean default false
   );
 
   procedure upload_and_parse
   (
-    pi_dgrm_name     in flow_diagrams.dgrm_name%type
-  , pi_dgrm_version  in flow_diagrams.dgrm_version%type
-  , pi_dgrm_category in flow_diagrams.dgrm_category%type
-  , pi_dgrm_content  in flow_diagrams.dgrm_content%type
-  , pi_dgrm_status   in flow_diagrams.dgrm_status%type default flow_constants_pkg.gc_dgrm_status_draft
+    pi_dgrm_name       in flow_diagrams.dgrm_name%type
+  , pi_dgrm_version    in flow_diagrams.dgrm_version%type
+  , pi_dgrm_category   in flow_diagrams.dgrm_category%type
+  , pi_dgrm_content    in flow_diagrams.dgrm_content%type
+  , pi_dgrm_status     in flow_diagrams.dgrm_status%type default flow_constants_pkg.gc_dgrm_status_draft
+  , pi_log_comment     in flow_flow_event_log.lgfl_comment%type default null
   , pi_force_overwrite in boolean default false
   );
 
@@ -59,7 +62,7 @@ as
     pi_dgrm_id      in flow_diagrams.dgrm_id%type
   , pi_dgrm_content in flow_diagrams.dgrm_content%type
   );
-  
+
   function add_diagram_version(
     pi_dgrm_id in flow_diagrams.dgrm_id%type,
     pi_dgrm_version in flow_diagrams.dgrm_version%type)

--- a/src/plsql/flow_instances.pks
+++ b/src/plsql/flow_instances.pks
@@ -9,7 +9,7 @@ create or replace package flow_instances
 --
 */
   authid definer
-  accessible by (flow_api_pkg, flow_engine, flow_proc_vars_int)
+  accessible by (flow_api_pkg, flow_engine, flow_proc_vars_int, flow_diagram)
 as
 
   function create_process

--- a/src/plsql/flow_log_admin.pkb
+++ b/src/plsql/flow_log_admin.pkb
@@ -17,6 +17,7 @@ create or replace package body flow_log_admin as
   ( destination_type               flow_types_pkg.t_vc200
   , db_table_name                  flow_types_pkg.t_vc200
   , db_id_column                   flow_types_pkg.t_vc200
+  , db_timestamp_column            flow_types_pkg.t_vc200
   , db_blob_column                 flow_types_pkg.t_vc200
   , oci_base_url                   flow_types_pkg.t_vc200
   , oci_bucket_name                flow_types_pkg.t_vc200
@@ -240,6 +241,8 @@ create or replace package body flow_log_admin as
   end validate_db_archive_location;*/
 
   function get_archive_location
+  ( p_archive_type   in varchar2
+  )
   return t_archive_location
   is
     l_archive_location              t_archive_location;
@@ -249,12 +252,12 @@ create or replace package body flow_log_admin as
     apex_debug.enter ( 'get_archive_location');
 
     l_destination_json      := flow_engine_util.get_config_value 
-                             ( p_config_key  => flow_constants_pkg.gc_config_logging_archive_location
+                             ( p_config_key  => p_archive_type
                              , p_default_value  => null);
 
     apex_debug.message 
     ( p_message => 'Retrieved configuration parameter %0 contents %1'
-    , p0 => flow_constants_pkg.gc_config_logging_archive_location
+    , p0 => p_archive_type
     , p1 => l_destination_json
     );                         
 
@@ -268,6 +271,7 @@ create or replace package body flow_log_admin as
     when flow_constants_pkg.gc_config_archive_destination_table then
       l_archive_location.db_table_name             := apex_json.get_varchar2 (p_path => 'tableDetails.tableName');
       l_archive_location.db_id_column              := apex_json.get_varchar2 (p_path => 'tableDetails.idColumn');
+      l_archive_location.db_timestamp_column       := apex_json.get_varchar2 (p_path => 'tableDetails.timestampColumn');
       l_archive_location.db_blob_column            := apex_json.get_varchar2 (p_path => 'tableDetails.blobColumn');
 
     when flow_constants_pkg.gc_config_archive_destination_oci_api then
@@ -306,7 +310,7 @@ create or replace package body flow_log_admin as
   end get_archive_location;
 
   procedure archive_to_database
-  ( p_process_id        in flow_processes.prcs_id%type
+  ( p_object_id         in number
   , p_archive           in blob
   , p_archive_location  in t_archive_location
   )
@@ -317,24 +321,25 @@ create or replace package body flow_log_admin as
 
   begin
     apex_debug.enter ( 'archive_to_database',
-    'instance', p_process_id
+    'instance', p_object_id
     );   
 
     l_insert_sql := 'insert into '
                     ||p_archive_location.db_table_name
                     ||' ( ' ||p_archive_location.db_id_column 
+                    ||' , ' ||p_archive_location.db_timestamp_column 
                     ||' , ' ||p_archive_location.db_blob_column
-                    ||' ) values ( :1, :2 )'
+                    ||' ) values ( :1, systimestamp,  :2 )'
                     ;
-    execute immediate l_insert_sql using p_process_id, p_archive;
+    execute immediate l_insert_sql using p_object_id, p_archive;
     apex_debug.message 
-    ( p_message => '-- Instance %0 inserted into archive to %1.%2'
-    , p0 => p_process_id
+    ( p_message => '-- Object %0 inserted into archive to %1.%2'
+    , p0 => p_object_id
     , p1 => p_archive_location.db_table_name
     , p2 => p_archive_location.db_blob_column
     ); 
   exception
-    when dup_val_on_index then 
+  /*  when dup_val_on_index then  -- added timestap column so this will not be called now...
       -- handle re-archive if the archive already exists.   This usually occurs if the process 
       -- was reset after archiving.
       l_update_sql := 'update '
@@ -345,17 +350,17 @@ create or replace package body flow_log_admin as
                       ||p_archive_location.db_id_column
                       ||' = :2 '
                       ;
-      execute immediate l_update_sql using p_archive, p_process_id;
+      execute immediate l_update_sql using p_archive, p_object_id;
       apex_debug.message 
-      ( p_message => '-- Instance %0 archive updated in %1.%2'
-      , p0 => p_process_id
+      ( p_message => '-- Object %0 archive updated in %1.%2'
+      , p0 => p_object_id
       , p1 => p_archive_location.db_table_name
       , p2 => p_archive_location.db_blob_column
-      );
+      ); */
     when others then
       apex_debug.message 
-      ( p_message => 'Archiving instance %0 into database column %1.%2 failed. Failed SQL: %3.'
-      , p0 => p_process_id
+      ( p_message => 'Archiving object %0 into database column %1.%2 failed. Failed SQL: %3.'
+      , p0 => p_object_id
       , p1 => p_archive_location.db_table_name
       , p2 => p_archive_location.db_blob_column
       , p3 => l_insert_sql
@@ -364,9 +369,10 @@ create or replace package body flow_log_admin as
   end archive_to_database;
 
   procedure archive_to_oci
-  ( p_process_id        in flow_processes.prcs_id%type
-  , p_archive           in blob
+  ( p_archive           in blob
   , p_archive_location  in t_archive_location
+  , p_object_name       in varchar2
+  , p_content_type      in varchar2
   )
   is
     l_url                       varchar2(4000);
@@ -375,14 +381,14 @@ create or replace package body flow_log_admin as
   begin
     l_url := p_archive_location.oci_request_url
               ||p_archive_location.oci_document_prefix
-              ||trim(to_char(p_process_id,'09999999'))||'.json';
+              ||p_object_name;
     apex_debug.message 
     ( p_message => 'Preparing Archive URL - URL : %0 Credential Static ID: %1'
     , p0 => l_url
     , p1 => p_archive_location.oci_credential_static_id
     );
     apex_web_service.g_request_headers(1).name :=  'Content-Type';
-    apex_web_service.g_request_headers(1).value :=  'application/json';
+    apex_web_service.g_request_headers(1).value :=  p_content_type;
     l_response :=  apex_web_service.make_rest_request
                    ( p_url          => l_url
                    , p_http_method  => 'PUT'
@@ -393,6 +399,50 @@ create or replace package body flow_log_admin as
       raise e_upload_failed_exception;
     end if;
   end archive_to_oci;
+
+  function archive_bpmn_diagram
+  ( p_dgrm_id            flow_diagrams.dgrm_id%type
+  , p_dgrm_content       flow_diagrams.dgrm_content%type
+  ) return flow_flow_event_log.lgfl_dgrm_archive_location%type
+  is
+    l_archive_blob        blob;
+    l_archive_location    t_archive_location;
+    l_timestamp           timestamp with time zone;
+    l_stored_location     flow_flow_event_log.lgfl_dgrm_archive_location%type;
+    l_object_name         flow_flow_event_log.lgfl_dgrm_archive_location%type;
+  begin
+    -- fix timestamp
+    l_timestamp := systimestamp at time zone 'UTC';
+    -- create bpmn blob
+    l_archive_blob := flow_util.clob_to_blob( pi_clob  => p_dgrm_content );
+    -- get archive location
+    l_archive_location := get_archive_location (p_archive_type => flow_constants_pkg.gc_config_logging_bpmn_location);
+    -- store in preferred location
+    case l_archive_location.destination_type
+    when flow_constants_pkg.gc_config_archive_destination_table then
+      archive_to_database ( p_object_id        => p_dgrm_id
+                          , p_archive          => l_archive_blob
+                          , p_archive_location => l_archive_location
+                          );
+      return l_archive_location.db_table_name;
+    when flow_constants_pkg.gc_config_archive_destination_oci_api then
+      l_object_name := trim(to_char(p_dgrm_id,'099999'))||'-'||to_char(l_timestamp,'YYYYMMDD-HH24MISS')||'.bpmn';
+      archive_to_oci      ( p_archive          => l_archive_blob
+                          , p_archive_location => l_archive_location
+                          , p_object_name      => l_object_name
+                          , p_content_type     => flow_constants_pkg.gc_mime_type_bpmn
+                          );   
+      return l_object_name;
+    when flow_constants_pkg.gc_config_archive_destination_oci_preauth then
+      l_object_name := trim(to_char(p_dgrm_id,'099999'))||'-'||to_char(l_timestamp,'YYYYMMDD-HH24MISS')||'.bpmn';
+      archive_to_oci      ( p_archive          => l_archive_blob
+                          , p_archive_location => l_archive_location
+                          , p_object_name      => l_object_name
+                          , p_content_type     => flow_constants_pkg.gc_mime_type_bpmn
+                          );  
+      return l_object_name;
+    end case;
+  end archive_bpmn_diagram;
 
   procedure archive_instance
   ( p_process_id         flow_processes.prcs_id%type
@@ -406,19 +456,21 @@ create or replace package body flow_log_admin as
     -- store in preferred location
     case p_archive_location.destination_type
     when flow_constants_pkg.gc_config_archive_destination_table then
-      archive_to_database ( p_process_id       => p_process_id
+      archive_to_database ( p_object_id        => p_process_id
                           , p_archive          => l_archive_blob
                           , p_archive_location => p_archive_location
                           );
     when flow_constants_pkg.gc_config_archive_destination_oci_api then
-      archive_to_oci      ( p_process_id       => p_process_id
-                          , p_archive          => l_archive_blob
+      archive_to_oci      ( p_archive          => l_archive_blob
                           , p_archive_location => p_archive_location
-                          );   
+                          , p_object_name      => trim(to_char(p_process_id,'09999999'))||'.json'
+                          , p_content_type     => flow_constants_pkg.gc_mime_type_json
+                          );  
     when flow_constants_pkg.gc_config_archive_destination_oci_preauth then
-      archive_to_oci      ( p_process_id       => p_process_id
-                          , p_archive          => l_archive_blob
+      archive_to_oci      ( p_archive          => l_archive_blob
                           , p_archive_location => p_archive_location
+                          , p_object_name      => trim(to_char(p_process_id,'09999999'))||'.json'
+                          , p_content_type     => flow_constants_pkg.gc_mime_type_json
                           );  
     end case;
     -- update instance with archive timestamp
@@ -469,7 +521,7 @@ create or replace package body flow_log_admin as
 
     if l_instances.count > 0 then
       -- get archive location
-      l_archive_location := get_archive_location;
+      l_archive_location := get_archive_location (p_archive_type => flow_constants_pkg.gc_config_logging_archive_location);
       -- loop over instances
       for instance in 1 .. l_instances.count
       loop

--- a/src/plsql/flow_log_admin.pks
+++ b/src/plsql/flow_log_admin.pks
@@ -13,7 +13,7 @@ create or replace package flow_log_admin
   --    - purging of instance log tables 
   */  
   authid definer
-  accessible by ( flow_admin_api, flow_instances )
+  accessible by ( flow_admin_api, flow_instances , flow_diagram, flow_logging)
   as
 
   function get_instance_json_summary
@@ -40,6 +40,11 @@ create or replace package flow_log_admin
   procedure purge_message_logs
   ( p_retention_period_days    in number default null
   );
-  
+
+  function archive_bpmn_diagram
+  ( p_dgrm_id            flow_diagrams.dgrm_id%type
+  , p_dgrm_content       flow_diagrams.dgrm_content%type
+  ) return flow_flow_event_log.lgfl_dgrm_archive_location%type;
+
 end flow_log_admin;
 /

--- a/src/plsql/flow_logging.pkb
+++ b/src/plsql/flow_logging.pkb
@@ -6,11 +6,31 @@ create or replace package body flow_logging as
 -- (c) Copyright MT AG, 2021-2022.
 --
 -- Created 29-Jul-2021  Richard Allen (Flowquest) for  MT AG
--- updated 10-Feb-2023  Richard Allen (Oracle)  
+-- Updated 10-Feb-2023  Richard Allen (Oracle)  
 --
 */
   g_logging_level           flow_configuration.cfig_value%type; 
   g_logging_hide_userid     flow_configuration.cfig_value%type;
+
+  procedure log_diagram_event
+  ( p_dgrm_id           in flow_diagrams.dgrm_id%type
+  , p_dgrm_name         in flow_diagrams.dgrm_name%type default null
+  , p_dgrm_version      in flow_diagrams.dgrm_version%type default null
+  , p_dgrm_status       in flow_diagrams.dgrm_status%type default null
+  , p_dgrm_category     in flow_diagrams.dgrm_category%type default null
+  , p_dgrm_content      in flow_diagrams.dgrm_content%type default null
+  , p_comment           in flow_flow_event_log.lgfl_comment%type default null
+  )
+  is
+  begin
+    if g_logging_level in ( flow_constants_pkg.gc_config_logging_level_secure
+                          , flow_constants_pkg.gc_config_logging_level_full
+                          ) 
+    then
+      null; -- not yet implemented
+    end if;
+
+  end log_diagram_event;
 
   procedure log_instance_event
   ( p_process_id        in flow_subflow_log.sflg_prcs_id%type

--- a/src/plsql/flow_logging.pks
+++ b/src/plsql/flow_logging.pks
@@ -10,7 +10,7 @@ create or replace package flow_logging
 --
 */
   authid definer
-  accessible by ( flow_diagrams, flow_engine, flow_instances, flow_proc_vars_int, flow_expressions 
+  accessible by ( flow_diagram, flow_engine, flow_instances, flow_proc_vars_int, flow_expressions 
                 , flow_boundary_events, flow_gateways, flow_tasks, flow_errors, flow_timers_pkg
                 , flow_call_activities, flow_subprocesses , flow_usertask_pkg)
 as

--- a/src/plsql/flow_logging.pks
+++ b/src/plsql/flow_logging.pks
@@ -10,10 +10,21 @@ create or replace package flow_logging
 --
 */
   authid definer
-  accessible by ( flow_engine, flow_instances, flow_proc_vars_int, flow_expressions 
+  accessible by ( flow_diagrams, flow_engine, flow_instances, flow_proc_vars_int, flow_expressions 
                 , flow_boundary_events, flow_gateways, flow_tasks, flow_errors, flow_timers_pkg
                 , flow_call_activities, flow_subprocesses , flow_usertask_pkg)
 as
+
+  procedure log_diagram_event
+  ( p_dgrm_id           in flow_diagrams.dgrm_id%type
+  , p_dgrm_name         in flow_diagrams.dgrm_name%type default null
+  , p_dgrm_version      in flow_diagrams.dgrm_version%type default null
+  , p_dgrm_status       in flow_diagrams.dgrm_status%type default null
+  , p_dgrm_category     in flow_diagrams.dgrm_category%type default null
+  , p_dgrm_content      in flow_diagrams.dgrm_content%type default null
+  , p_comment           in flow_flow_event_log.lgfl_comment%type default null
+  );
+
 
   procedure log_instance_event
   ( p_process_id        in flow_subflow_log.sflg_prcs_id%type


### PR DESCRIPTION
- adds logging to bpmn diagrams
- logs meta-data changes to flow_flow_event_log
- creates copy of bpmn file when status > 'draft' when diagram gets released or changed - into database or OCI Object Storage
- refactors flow_bpmn_parser_pkg so that uploading functions are now handled in flow_diagram.
- fixes bug in flow_diagrams.delete diagram where process instances were deleted without going through flow_instances.delete_process
- completes auditing functionality for 23.1