### PR TITLE
Test Suite and bug fixes for message flow

### DIFF
--- a/src/data/install_engine_messages_en.sql
+++ b/src/data/install_engine_messages_en.sql
@@ -257,7 +257,8 @@ begin
     values ( 'settings-error', c_load_lang, q'[Error evaluating Setting. Expression is invalid.  Expression: %0.]' );
   insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
     values ( 'settings-procvar-no-prcs', c_load_lang, q'[Settings cannot specify Process Variable without a Process ID.]' );
-
+  insert into flow_messages( fmsg_message_key, fmsg_lang, fmsg_message_content )
+    values ( 'msgflow-endpoint-not-supported', c_load_lang, q'[MessageFlow Endpoint specified ( %0 ) is not supported.]' );
 
   commit;
 end;

--- a/src/plsql/flow_boundary_events.pkb
+++ b/src/plsql/flow_boundary_events.pkb
@@ -282,6 +282,11 @@ is
     ( p_process_id => p_process_id
     , p_subflow_id => p_subflow_id
     );
+    -- clean up any subscriptions for message events on the object
+    flow_message_util.cancel_subscription
+    ( p_process_id => p_process_id
+    , p_subflow_id => p_subflow_id
+    );
     -- generate a step key & insert in the update...use later
     l_timestamp := systimestamp;
     l_step_key := flow_engine_util.step_key ( pi_sbfl_id   => p_subflow_id

--- a/src/plsql/flow_constants_pkg.pks
+++ b/src/plsql/flow_constants_pkg.pks
@@ -128,7 +128,8 @@ as
   gc_apex_servicetask_immediately     constant flow_types_pkg.t_bpmn_id := gc_apex_prefix || 'immediately';
 
   --receiveTask
-  gc_apex_receivetask_subtype_basic   constant flow_types_pkg.t_bpmn_id :=  'basicApexMessage';
+  gc_apex_receivetask_subtype_basic   constant flow_types_pkg.t_bpmn_id :=  gc_apex_prefix ||'basicApexMessage';    ----   fix before production also in flow_tasks...
+  gc_message_task_type                constant flow_types_pkg.t_bpmn_id :=  'basicApexMessage';
    
   -- execute PL/SQL tasks
   gc_apex_task_execute_plsql    constant flow_types_pkg.t_bpmn_id := gc_apex_prefix || 'executePlsql';

--- a/src/plsql/flow_engine.pks
+++ b/src/plsql/flow_engine.pks
@@ -33,6 +33,12 @@ procedure restart_step
   , p_step_key            in flow_subflows.sbfl_step_key%type default null
   , p_comment             in flow_instance_event_log.lgpr_comment%type default null
   );
+
+procedure handle_event_gateway_event
+  ( p_process_id         in flow_processes.prcs_id%type
+  , p_parent_subflow_id  in flow_subflows.sbfl_id%type
+  , p_cleared_subflow_id in flow_subflows.sbfl_id%type
+  );
   
 end flow_engine;
 /

--- a/src/plsql/flow_log_admin.pkb
+++ b/src/plsql/flow_log_admin.pkb
@@ -249,13 +249,13 @@ create or replace package body flow_log_admin as
     , p0 => p_archive_type
     , p1 => l_destination_json
     );                         
-dbms_output.put_line('archive destination'||l_destination_json);
+    -- dbms_output.put_line('archive destination'||l_destination_json);
     apex_json.parse (p_source => l_destination_json);
 
     l_archive_location.destination_type            := apex_json.get_varchar2 (p_path => 'destinationType');
 
     apex_debug.message (p_message => '--- Destination Type : %0', p0=> l_archive_location.destination_type);  
-    dbms_output.put_line('--- Destination Type : '||l_archive_location.destination_type);
+    -- dbms_output.put_line('--- Destination Type : '||l_archive_location.destination_type);
 
     case l_archive_location.destination_type 
     when flow_constants_pkg.gc_config_archive_destination_table then
@@ -491,7 +491,7 @@ dbms_output.put_line('archive destination'||l_destination_json);
     );
     -- get list of process instances to archive, if a single p_process_id was not passed in.
     -- get all completed ('completed' or 'terminated') non-archived instances
-            dbms_output.put_line('Archiving starting');
+    -- dbms_output.put_line('Archiving starting');
     if p_process_id is null then
       select prcs.prcs_id
         bulk collect into l_instances
@@ -511,15 +511,15 @@ dbms_output.put_line('archive destination'||l_destination_json);
     , p0 => l_instances.count);
 
     if l_instances.count > 0 then
-     dbms_output.put_line('getting location');
+      -- dbms_output.put_line('getting location');
       -- get archive location
       l_archive_location := get_archive_location (p_archive_type => flow_constants_pkg.gc_config_logging_archive_location);
-      dbms_output.put_line('got location');
+      --dbms_output.put_line('got location');
       -- loop over instances
       for instance in 1 .. l_instances.count
       loop
         -- lock flow_processes?
-        dbms_output.put_line('Archiving process '||l_instances(instance).prcs_id);
+        -- dbms_output.put_line('Archiving process '||l_instances(instance).prcs_id);
         archive_instance ( p_process_id => l_instances(instance).prcs_id
                          , p_archive_location => l_archive_location
                          );

--- a/src/plsql/flow_message_flow.pkb
+++ b/src/plsql/flow_message_flow.pkb
@@ -10,6 +10,7 @@ create or replace package body flow_message_flow as
   e_lock_timeout exception;
   pragma exception_init (e_lock_timeout, -3006);
 
+
   function subscribe
   ( p_subscription_details     in t_subscription_details
   ) return flow_message_subscriptions.msub_id%type
@@ -75,15 +76,10 @@ create or replace package body flow_message_flow as
       ;
     exception
         when no_data_found then
-          flow_errors.handle_general_error
-          ( pi_message_key => 'msgflow-not-correlated');
-          raise no_data_found;
+          raise e_msgflow_msg_not_correlated;
           -- logging of incorrect message handled in procedure exceptions below...
         when e_lock_timeout then
-          flow_errors.handle_general_error
-          ( pi_message_key => 'msgflow-lock-timeout-msub');
-          raise no_data_found;          
-          
+          raise e_msgflow_correlated_msg_locked;          
     end;
     -- message is correlated.  create an APEX session if coming from outside
     -- and then validate the step key to make sure the receive / catch is still current
@@ -106,14 +102,9 @@ create or replace package body flow_message_flow as
     exception
       when no_data_found then
           -- add some message-specific logging capability into here.
-          flow_errors.handle_general_error
-          ( pi_message_key => 'msgflow-no-longer-current-step');
-          raise no_data_found;
+          raise e_msgflow_mag_already_consumed ;
       when e_lock_timeout then
-          -- add some message-specific logging capability into here.
-          flow_errors.handle_general_error
-          ( pi_message_key => 'msgflow-lock-timeout-subflow');
-          raise no_data_found;          
+          raise e_msgflow_correlated_msg_locked;          
     end;
 
     -- store payload, if present
@@ -205,7 +196,8 @@ create or replace package body flow_message_flow as
   , p_step_info     in flow_types_pkg.flow_step_info
   )
   is
-    l_message       flow_message_flow.t_flow_basic_message;
+    l_message               flow_message_flow.t_flow_basic_message;
+    e_msgflow_bad_endpoint  exception;
   begin
       apex_debug.enter 
     ( 'send_message'
@@ -225,6 +217,40 @@ create or replace package body flow_message_flow as
         , p_key_value       => l_message.key_value
         , p_payload         => l_message.payload
         );
+      exception
+        when e_msgflow_msg_not_correlated then
+          -- message sent did not match an existing subscription
+          flow_errors.handle_instance_error
+          ( pi_prcs_id      => p_sbfl_info.sbfl_prcs_id
+          , pi_sbfl_id      => p_sbfl_info.sbfl_id
+          , pi_message_key  => 'msgflow-not-correlated' 
+          );
+        when e_msgflow_correlated_msg_locked then
+          -- message sent correated but is locked by another message
+          flow_errors.handle_instance_error
+          ( pi_prcs_id      => p_sbfl_info.sbfl_prcs_id
+          , pi_sbfl_id      => p_sbfl_info.sbfl_id
+          , pi_message_key  => 'msgflow-lock-timeout-msub' 
+          );
+        when e_msgflow_mag_already_consumed then
+          -- message correlated but receiving object is no longer the current object in its subflow
+          flow_errors.handle_instance_error
+          ( pi_prcs_id      => p_sbfl_info.sbfl_prcs_id
+          , pi_sbfl_id      => p_sbfl_info.sbfl_id
+          , pi_message_key  => 'msgflow-no-longer-current-step'
+          );
+      end;
+    else
+      begin
+        raise e_msgflow_bad_endpoint;
+      exception
+        when e_msgflow_bad_endpoint then
+          flow_errors.handle_instance_error
+          ( pi_prcs_id      => p_sbfl_info.sbfl_prcs_id
+          , pi_sbfl_id      => p_sbfl_info.sbfl_id
+          , pi_message_key  => 'msgflow-endpoint-not-supported' 
+          , p0 => l_message.endpoint
+          );
       end;
     end case;
 

--- a/src/plsql/flow_message_flow.pks
+++ b/src/plsql/flow_message_flow.pks
@@ -27,6 +27,10 @@ create or replace package flow_message_flow as
   , payload       clob 
   );  
 
+  e_msgflow_msg_not_correlated exception;
+  e_msgflow_correlated_msg_locked exception;
+  e_msgflow_mag_already_consumed exception;
+
   function subscribe
   ( p_subscription_details     in t_subscription_details
   ) return flow_message_subscriptions.msub_id%type;

--- a/src/plsql/flow_message_util.pks
+++ b/src/plsql/flow_message_util.pks
@@ -11,7 +11,7 @@ create or replace package flow_message_util
 --
 */
   accessible by ( flow_message_flow, flow_tasks, flow_engine , flow_instances 
-                , flow_engine_util )
+                , flow_engine_util , flow_boundary_events )
 as  
 
   function get_msg_subscription_details

--- a/src/plsql/flow_tasks.pkb
+++ b/src/plsql/flow_tasks.pkb
@@ -596,9 +596,18 @@ create or replace package body flow_tasks as
     , 'p_step_info.target_objt_tag', p_step_info.target_objt_tag 
     );
 
-    
-    case get_task_type( p_step_info.target_objt_id )
-    when flow_constants_pkg.gc_apex_receivetask_subtype_basic then
+    -- set boundaryEvent Timers, if any
+    flow_boundary_events.set_boundary_timers 
+    ( p_process_id => p_sbfl_info.sbfl_prcs_id
+    , p_subflow_id => p_sbfl_info.sbfl_id
+    );  
+        
+--    case get_task_type( p_step_info.target_objt_id )
+--    when flow_constants_pkg.gc_apex_receivetask_subtype_basic then
+
+      case
+      when  get_task_type( p_step_info.target_objt_id ) in ( flow_constants_pkg.gc_apex_receivetask_subtype_basic -- temp
+                                                           , flow_constants_pkg.gc_message_task_type) then
  
         l_msg_sub            := flow_message_util.get_msg_subscription_details
                                 ( p_msg_object_bpmn_id      => p_step_info.target_objt_ref
@@ -626,7 +635,9 @@ create or replace package body flow_tasks as
         ( p_message => '-- ReceiveTask subscription created - message subscription id: %0'
         , p0 => l_msub_id
         );
-    when flow_constants_pkg.gc_apex_task_execute_plsql then
+
+      when  get_task_type( p_step_info.target_objt_id ) = flow_constants_pkg.gc_apex_task_execute_plsql then        --- temp
+--     when flow_constants_pkg.gc_apex_task_execute_plsql then
         -- set work started time
         flow_engine.start_step 
         ( p_process_id => p_sbfl_info.sbfl_prcs_id
@@ -663,6 +674,8 @@ create or replace package body flow_tasks as
     l_current             flow_objects.objt_bpmn_id%type;
     l_scope               flow_process_variables.prov_scope%type;
     l_dgrm_id             flow_diagrams.dgrm_id%type;
+    l_follows_ebg         flow_subflows.sbfl_is_following_ebg%type; 
+    l_parent_sbfl         flow_subflows.sbfl_sbfl_id%type;
     e_incorrect_step_key  exception;
   begin
     apex_debug.enter 
@@ -684,9 +697,13 @@ create or replace package body flow_tasks as
       select sbfl.sbfl_step_key
            , sbfl.sbfl_current
            , sbfl.sbfl_dgrm_id
+           , sbfl.sbfl_is_following_ebg
+           , sbfl.sbfl_sbfl_id
         into l_required_step_key
            , l_current
            , l_dgrm_id
+           , l_follows_ebg
+           , l_parent_sbfl
         from flow_objects objt
         join flow_subflows sbfl
           on sbfl.sbfl_dgrm_id = objt.objt_dgrm_id
@@ -706,27 +723,41 @@ create or replace package body flow_tasks as
         null; -- tbi
     end; 
 
-    -- set subflow to running
-    update flow_subflows sbfl
-       set sbfl.sbfl_last_update    = systimestamp
-         , sbfl.sbfl_work_started   = systimestamp
-         , sbfl.sbfl_status         = flow_constants_pkg.gc_sbfl_status_running
-         , sbfl.sbfl_last_update_by = coalesce  ( sys_context('apex$session','app_user') 
-                                                , sys_context('userenv','os_user')
-                                                , sys_context('userenv','session_user')
-                                                )  
-     where sbfl.sbfl_id       = p_subflow_id
-       and sbfl.sbfl_prcs_id  = p_process_id
-      ;
-    -- log message receipt event
+    -- handle a receivetask following an Event Based Gateway
+
+    case  l_follows_ebg 
+    when  'Y' then
+        -- we have an eventBasedGateway - handle cleaning up the other forward paths
+        flow_engine.handle_event_gateway_event 
+        (
+          p_process_id => p_process_id
+        , p_parent_subflow_id => l_parent_sbfl
+        , p_cleared_subflow_id => p_subflow_id
+        );      
+
+    else 
+      -- set subflow to running
+      update flow_subflows sbfl
+         set sbfl.sbfl_last_update    = systimestamp
+           , sbfl.sbfl_work_started   = systimestamp
+           , sbfl.sbfl_status         = flow_constants_pkg.gc_sbfl_status_running
+           , sbfl.sbfl_last_update_by = coalesce  ( sys_context('apex$session','app_user') 
+                                                  , sys_context('userenv','os_user')
+                                                  , sys_context('userenv','session_user')
+                                                  )  
+       where sbfl.sbfl_id       = p_subflow_id
+         and sbfl.sbfl_prcs_id  = p_process_id
+        ;
+      -- log message receipt event
 
 
-    -- step subflow forward
-    flow_engine.flow_complete_step 
-    ( p_process_id => p_process_id
-    , p_subflow_id => p_subflow_id
-    , p_step_key   => p_step_key
-    );
+      -- step subflow forward
+      flow_engine.flow_complete_step 
+      ( p_process_id => p_process_id
+      , p_subflow_id => p_subflow_id
+      , p_step_key   => p_step_key
+      );
+    end case;
 
   end receiveTask_callback;
   

--- a/src/views/flow_subflows_vw.sql
+++ b/src/views/flow_subflows_vw.sql
@@ -28,6 +28,8 @@ as
         , sbfl.sbfl_status
         , sbfl.sbfl_lane as sbfl_current_lane
         , sbfl.sbfl_lane_name as sbfl_current_lane_name
+        , sbfl.sbfl_lane_isrole
+        , sbfl.sbfl_lane_role
         , sbfl.sbfl_process_level
         , sbfl.sbfl_diagram_level
         , sbfl.sbfl_scope

--- a/test/install_all_tests.sql
+++ b/test/install_all_tests.sql
@@ -13,6 +13,8 @@ PROMPT >> Installing Package Specifications
 @plsql/test_002_gateway.pks
 @plsql/test_003_startEvents.pks
 @plsql/test_004_proc_vars.pks
+@plsql/test_005_engine_misc.pks
+@plsql/test_006_lanes_roles.pks
 @plsql/test_009_call_activity_nesting.pks
 @plsql/test_010_variable_expression.pks
 @plsql/test_011_var_exps_in_callActivities.pks
@@ -23,6 +25,8 @@ PROMPT >> Installing Package Specifications
 @plsql/test_016_splitting_gw_errors.pks
 @plsql/test_017_exc_gw_errors_restarts.pks
 @plsql/test_018_gw_routing_exps.pks
+@plsql/test_019_priorityduedates.pks
+@plsql/test_021_messageflow_basics.pks
 
 PROMPT >> Installing Package Bodies
 
@@ -30,8 +34,10 @@ PROMPT >> Installing Package Bodies
 @plsql/test_001_api.pkb
 @plsql/test_002_gateway.pkb
 @plsql/test_003_startEvents.pkb
-@plsql/test_004_proc_vars.pks
-@plsql/test_009_call_activity_nesting.pks
+@plsql/test_004_proc_vars.pkb
+@plsql/test_005_engine_misc.pkb
+@plsql/test_006_lanes_roles.pkb
+@plsql/test_009_call_activity_nesting.pkb
 @plsql/test_010_variable_expression.pkb
 @plsql/test_011_var_exps_in_callActivities.pkb
 @plsql/test_012_call_activity_timer_BEs.pkb
@@ -41,7 +47,8 @@ PROMPT >> Installing Package Bodies
 @plsql/test_016_splitting_gw_errors.pkb
 @plsql/test_017_exc_gw_errors_restarts.pkb
 @plsql/test_018_gw_routing_exps.pkb
-
+@plsql/test_019_priorityduedates.pkb
+@plsql/test_021_messageflow_basics.pkb
 
 PROMPT >> Engine Test Scripts Installed
 

--- a/test/models/A21a - Messageflow - basics_0.bpmn
+++ b/test/models/A21a - Messageflow - basics_0.bpmn
@@ -1,0 +1,358 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:apex="https://flowsforapex.org" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1wzb475" targetNamespace="http://bpmn.io/schema/b" exporter="Flows for APEX" exporterVersion="23.1.0">
+  <bpmn:process id="Process_A21a" name="A21a - Basic MessageFlow" isExecutable="false" apex:manualInput="false">
+    <bpmn:startEvent id="Event_078jhcp" name="Start">
+      <bpmn:outgoing>Flow_10cbwc9</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_10cbwc9" sourceRef="Event_078jhcp" targetRef="Activity_Before" />
+    <bpmn:intermediateThrowEvent id="ITE" name="ITE" apex:type="basicApexMessage">
+      <bpmn:incoming>Flow_0u9rc68</bpmn:incoming>
+      <bpmn:outgoing>Flow_1148c6v</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_03dkrir">
+        <bpmn:extensionElements>
+          <apex:endpoint>
+            <apex:expressionType>static</apex:expressionType>
+            <apex:expression>local</apex:expression>
+          </apex:endpoint>
+          <apex:messageName>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageName</apex:expression>
+          </apex:messageName>
+          <apex:correlationKey>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageKey</apex:expression>
+          </apex:correlationKey>
+          <apex:correlationValue>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageValue</apex:expression>
+          </apex:correlationValue>
+          <apex:payload>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messagePayload</apex:expression>
+          </apex:payload>
+        </bpmn:extensionElements>
+      </bpmn:messageEventDefinition>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:task id="Activity_AfterITE" name="After ITE">
+      <bpmn:incoming>Flow_1148c6v</bpmn:incoming>
+      <bpmn:outgoing>Flow_00v5eu3</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1148c6v" sourceRef="ITE" targetRef="Activity_AfterITE" />
+    <bpmn:endEvent id="Event_ITEEnd" name="ITEEnd">
+      <bpmn:incoming>Flow_00v5eu3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_00v5eu3" sourceRef="Activity_AfterITE" targetRef="Event_ITEEnd" />
+    <bpmn:task id="Activity_Before" name="Before">
+      <bpmn:extensionElements>
+        <apex:beforeTask>
+          <apex:processVariable>
+            <apex:varSequence>0</apex:varSequence>
+            <apex:varName>messageKey</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>keya21a</apex:varExpression>
+          </apex:processVariable>
+          <apex:processVariable>
+            <apex:varSequence>1</apex:varSequence>
+            <apex:varName>messageName</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>MyMessage</apex:varExpression>
+          </apex:processVariable>
+          <apex:processVariable>
+            <apex:varSequence>2</apex:varSequence>
+            <apex:varName>messageValue</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>a21a</apex:varExpression>
+          </apex:processVariable>
+          <apex:processVariable>
+            <apex:varSequence>3</apex:varSequence>
+            <apex:varName>messagePayload</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>originalPayload</apex:varExpression>
+          </apex:processVariable>
+        </apex:beforeTask>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_10cbwc9</bpmn:incoming>
+      <bpmn:outgoing>Flow_0b0bmnc</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0b0bmnc" sourceRef="Activity_Before" targetRef="Gateway_0d8vbql" />
+    <bpmn:exclusiveGateway id="Gateway_0d8vbql" name="switch">
+      <bpmn:incoming>Flow_0b0bmnc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0u9rc68</bpmn:outgoing>
+      <bpmn:outgoing>Flow_10th9vn</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1nhu01n</bpmn:outgoing>
+      <bpmn:outgoing>Flow_13sn2b2</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0u9rc68" name="path = &#39;ITE&#39;" sourceRef="Gateway_0d8vbql" targetRef="ITE" apex:sequence="10">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'ITE' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_10th9vn" name="path = &#39;ICE&#39;" sourceRef="Gateway_0d8vbql" targetRef="ICE" apex:sequence="20">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'ICE' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:intermediateCatchEvent id="ICE" name="ICE" apex:type="basicApexMessage">
+      <bpmn:incoming>Flow_10th9vn</bpmn:incoming>
+      <bpmn:outgoing>Flow_16rs7dc</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0xcaexo">
+        <bpmn:extensionElements>
+          <apex:messageName>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageName</apex:expression>
+          </apex:messageName>
+          <apex:correlationKey>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageKey</apex:expression>
+          </apex:correlationKey>
+          <apex:correlationValue>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageValue</apex:expression>
+          </apex:correlationValue>
+          <apex:payloadVariable>returnPayload</apex:payloadVariable>
+        </bpmn:extensionElements>
+      </bpmn:messageEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:task id="Activity_AfterICE" name="After ICE">
+      <bpmn:incoming>Flow_16rs7dc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rlvoek</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_16rs7dc" sourceRef="ICE" targetRef="Activity_AfterICE" />
+    <bpmn:endEvent id="Event_ICEEnd" name="ICEEnd">
+      <bpmn:incoming>Flow_0rlvoek</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0rlvoek" sourceRef="Activity_AfterICE" targetRef="Event_ICEEnd" />
+    <bpmn:sequenceFlow id="Flow_1nhu01n" name="path = &#39;Send&#39;" sourceRef="Gateway_0d8vbql" targetRef="Send" apex:sequence="30">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'Send' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sendTask id="Send" name="Send" apex:type="basicApexMessage">
+      <bpmn:extensionElements>
+        <apex:endpoint>
+          <apex:expressionType>static</apex:expressionType>
+          <apex:expression>local</apex:expression>
+        </apex:endpoint>
+        <apex:messageName>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageName</apex:expression>
+        </apex:messageName>
+        <apex:correlationKey>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageKey</apex:expression>
+        </apex:correlationKey>
+        <apex:correlationValue>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageValue</apex:expression>
+        </apex:correlationValue>
+        <apex:payload>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messagePayload</apex:expression>
+        </apex:payload>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1nhu01n</bpmn:incoming>
+      <bpmn:outgoing>Flow_0a7ljx8</bpmn:outgoing>
+    </bpmn:sendTask>
+    <bpmn:task id="Activity_AfterSend" name="After SendTask">
+      <bpmn:incoming>Flow_0a7ljx8</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ktvql5</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0a7ljx8" sourceRef="Send" targetRef="Activity_AfterSend" />
+    <bpmn:endEvent id="Event_SendEnd" name="SendEnd">
+      <bpmn:incoming>Flow_0ktvql5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0ktvql5" sourceRef="Activity_AfterSend" targetRef="Event_SendEnd" />
+    <bpmn:sequenceFlow id="Flow_13sn2b2" name="path = &#39;Receive&#39;" sourceRef="Gateway_0d8vbql" targetRef="Receive" apex:sequence="40">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'Receive' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:receiveTask id="Receive" name="Receive" apex:type="basicApexMessage">
+      <bpmn:extensionElements>
+        <apex:messageName>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageName</apex:expression>
+        </apex:messageName>
+        <apex:correlationKey>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageKey</apex:expression>
+        </apex:correlationKey>
+        <apex:correlationValue>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageValue</apex:expression>
+        </apex:correlationValue>
+        <apex:payloadVariable>returnPayload</apex:payloadVariable>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_13sn2b2</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gx36mi</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:task id="Activity_AfterReceive" name="After Receive">
+      <bpmn:incoming>Flow_1gx36mi</bpmn:incoming>
+      <bpmn:outgoing>Flow_122voy1</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1gx36mi" sourceRef="Receive" targetRef="Activity_AfterReceive" />
+    <bpmn:endEvent id="Event_ReceiveEnd" name="ReceiveEnd">
+      <bpmn:incoming>Flow_122voy1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_122voy1" sourceRef="Activity_AfterReceive" targetRef="Event_ReceiveEnd" apex:sequence="10" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_A21a">
+      <bpmndi:BPMNShape id="Event_078jhcp_di" bpmnElement="Event_078jhcp">
+        <dc:Bounds x="162" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="168" y="495" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04w6zzy_di" bpmnElement="ITE">
+        <dc:Bounds x="642" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="651" y="495" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09ryfbc_di" bpmnElement="Activity_AfterITE">
+        <dc:Bounds x="740" y="430" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_023t4ki_di" bpmnElement="Event_ITEEnd">
+        <dc:Bounds x="902" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="902" y="495" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ius2or_di" bpmnElement="Activity_Before">
+        <dc:Bounds x="270" y="430" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0d8vbql_di" bpmnElement="Gateway_0d8vbql" isMarkerVisible="true">
+        <dc:Bounds x="415" y="445" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="374" y="433" width="31" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03abwhg_di" bpmnElement="ICE">
+        <dc:Bounds x="642" y="562" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="651" y="605" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0e91je8_di" bpmnElement="Activity_AfterICE">
+        <dc:Bounds x="740" y="540" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tsgkvz_di" bpmnElement="Event_ICEEnd">
+        <dc:Bounds x="902" y="562" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="901" y="605" width="38" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hxbrc5_di" bpmnElement="Send">
+        <dc:Bounds x="610" y="650" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mgopxu_di" bpmnElement="Activity_AfterSend">
+        <dc:Bounds x="760" y="650" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0pbphoc_di" bpmnElement="Event_SendEnd">
+        <dc:Bounds x="912" y="672" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="907" y="715" width="46" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ouv7wz_di" bpmnElement="Receive">
+        <dc:Bounds x="610" y="760" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12b9wva_di" bpmnElement="Activity_AfterReceive">
+        <dc:Bounds x="760" y="760" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0v2m07w_di" bpmnElement="Event_ReceiveEnd">
+        <dc:Bounds x="912" y="782" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="900" y="825" width="60" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_10cbwc9_di" bpmnElement="Flow_10cbwc9">
+        <di:waypoint x="198" y="470" />
+        <di:waypoint x="270" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1148c6v_di" bpmnElement="Flow_1148c6v">
+        <di:waypoint x="678" y="470" />
+        <di:waypoint x="740" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00v5eu3_di" bpmnElement="Flow_00v5eu3">
+        <di:waypoint x="840" y="470" />
+        <di:waypoint x="902" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b0bmnc_di" bpmnElement="Flow_0b0bmnc">
+        <di:waypoint x="370" y="470" />
+        <di:waypoint x="415" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u9rc68_di" bpmnElement="Flow_0u9rc68">
+        <di:waypoint x="465" y="470" />
+        <di:waypoint x="642" y="470" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="527" y="452" width="56" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10th9vn_di" bpmnElement="Flow_10th9vn">
+        <di:waypoint x="440" y="495" />
+        <di:waypoint x="440" y="580" />
+        <di:waypoint x="642" y="580" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="521" y="553" width="57" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16rs7dc_di" bpmnElement="Flow_16rs7dc">
+        <di:waypoint x="678" y="580" />
+        <di:waypoint x="740" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rlvoek_di" bpmnElement="Flow_0rlvoek">
+        <di:waypoint x="840" y="580" />
+        <di:waypoint x="902" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nhu01n_di" bpmnElement="Flow_1nhu01n">
+        <di:waypoint x="440" y="495" />
+        <di:waypoint x="440" y="690" />
+        <di:waypoint x="610" y="690" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="518" y="653" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0a7ljx8_di" bpmnElement="Flow_0a7ljx8">
+        <di:waypoint x="710" y="690" />
+        <di:waypoint x="760" y="690" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ktvql5_di" bpmnElement="Flow_0ktvql5">
+        <di:waypoint x="860" y="690" />
+        <di:waypoint x="912" y="690" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13sn2b2_di" bpmnElement="Flow_13sn2b2">
+        <di:waypoint x="440" y="495" />
+        <di:waypoint x="440" y="800" />
+        <di:waypoint x="610" y="800" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="491" y="773" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gx36mi_di" bpmnElement="Flow_1gx36mi">
+        <di:waypoint x="710" y="800" />
+        <di:waypoint x="760" y="800" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_122voy1_di" bpmnElement="Flow_122voy1">
+        <di:waypoint x="860" y="800" />
+        <di:waypoint x="912" y="800" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/models/A21b - Messageflow - basics - no payload_0.bpmn
+++ b/test/models/A21b - Messageflow - basics - no payload_0.bpmn
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:apex="https://flowsforapex.org" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1wzb475" targetNamespace="http://bpmn.io/schema/b" exporter="Flows for APEX" exporterVersion="23.1.0">
+  <bpmn:process id="Process_A21a" name="A21a - Basic MessageFlow" isExecutable="false" apex:manualInput="false">
+    <bpmn:startEvent id="Event_078jhcp" name="Start">
+      <bpmn:outgoing>Flow_10cbwc9</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_10cbwc9" sourceRef="Event_078jhcp" targetRef="Activity_Before" />
+    <bpmn:intermediateThrowEvent id="ITE" name="ITE" apex:type="basicApexMessage">
+      <bpmn:incoming>Flow_0u9rc68</bpmn:incoming>
+      <bpmn:outgoing>Flow_1148c6v</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_03dkrir">
+        <bpmn:extensionElements>
+          <apex:endpoint>
+            <apex:expressionType>static</apex:expressionType>
+            <apex:expression>local</apex:expression>
+          </apex:endpoint>
+          <apex:messageName>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageName</apex:expression>
+          </apex:messageName>
+          <apex:correlationKey>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageKey</apex:expression>
+          </apex:correlationKey>
+          <apex:correlationValue>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageValue</apex:expression>
+          </apex:correlationValue>
+        </bpmn:extensionElements>
+      </bpmn:messageEventDefinition>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:task id="Activity_AfterITE" name="After ITE">
+      <bpmn:incoming>Flow_1148c6v</bpmn:incoming>
+      <bpmn:outgoing>Flow_00v5eu3</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1148c6v" sourceRef="ITE" targetRef="Activity_AfterITE" />
+    <bpmn:endEvent id="Event_ITEEnd" name="ITEEnd">
+      <bpmn:incoming>Flow_00v5eu3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_00v5eu3" sourceRef="Activity_AfterITE" targetRef="Event_ITEEnd" />
+    <bpmn:task id="Activity_Before" name="Before">
+      <bpmn:extensionElements>
+        <apex:beforeTask>
+          <apex:processVariable>
+            <apex:varSequence>0</apex:varSequence>
+            <apex:varName>messageKey</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>keya21a</apex:varExpression>
+          </apex:processVariable>
+          <apex:processVariable>
+            <apex:varSequence>1</apex:varSequence>
+            <apex:varName>messageName</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>MyMessage</apex:varExpression>
+          </apex:processVariable>
+          <apex:processVariable>
+            <apex:varSequence>2</apex:varSequence>
+            <apex:varName>messageValue</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>a21a</apex:varExpression>
+          </apex:processVariable>
+        </apex:beforeTask>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_10cbwc9</bpmn:incoming>
+      <bpmn:outgoing>Flow_0b0bmnc</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0b0bmnc" sourceRef="Activity_Before" targetRef="Gateway_0d8vbql" />
+    <bpmn:exclusiveGateway id="Gateway_0d8vbql" name="switch">
+      <bpmn:incoming>Flow_0b0bmnc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0u9rc68</bpmn:outgoing>
+      <bpmn:outgoing>Flow_10th9vn</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1nhu01n</bpmn:outgoing>
+      <bpmn:outgoing>Flow_13sn2b2</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0u9rc68" name="path = &#39;ITE&#39;" sourceRef="Gateway_0d8vbql" targetRef="ITE" apex:sequence="10">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'ITE' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_10th9vn" name="path = &#39;ICE&#39;" sourceRef="Gateway_0d8vbql" targetRef="ICE" apex:sequence="20">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'ICE' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:intermediateCatchEvent id="ICE" name="ICE" apex:type="basicApexMessage">
+      <bpmn:incoming>Flow_10th9vn</bpmn:incoming>
+      <bpmn:outgoing>Flow_16rs7dc</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0xcaexo">
+        <bpmn:extensionElements>
+          <apex:messageName>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageName</apex:expression>
+          </apex:messageName>
+          <apex:correlationKey>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageKey</apex:expression>
+          </apex:correlationKey>
+          <apex:correlationValue>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageValue</apex:expression>
+          </apex:correlationValue>
+        </bpmn:extensionElements>
+      </bpmn:messageEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:task id="Activity_AfterICE" name="After ICE">
+      <bpmn:incoming>Flow_16rs7dc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rlvoek</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_16rs7dc" sourceRef="ICE" targetRef="Activity_AfterICE" />
+    <bpmn:endEvent id="Event_ICEEnd" name="ICEEnd">
+      <bpmn:incoming>Flow_0rlvoek</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0rlvoek" sourceRef="Activity_AfterICE" targetRef="Event_ICEEnd" />
+    <bpmn:sequenceFlow id="Flow_1nhu01n" name="path = &#39;Send&#39;" sourceRef="Gateway_0d8vbql" targetRef="Send" apex:sequence="30">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'Send' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sendTask id="Send" name="Send" apex:type="basicApexMessage">
+      <bpmn:extensionElements>
+        <apex:endpoint>
+          <apex:expressionType>static</apex:expressionType>
+          <apex:expression>local</apex:expression>
+        </apex:endpoint>
+        <apex:messageName>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageName</apex:expression>
+        </apex:messageName>
+        <apex:correlationKey>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageKey</apex:expression>
+        </apex:correlationKey>
+        <apex:correlationValue>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageValue</apex:expression>
+        </apex:correlationValue>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1nhu01n</bpmn:incoming>
+      <bpmn:outgoing>Flow_0a7ljx8</bpmn:outgoing>
+    </bpmn:sendTask>
+    <bpmn:task id="Activity_AfterSend" name="After SendTask">
+      <bpmn:incoming>Flow_0a7ljx8</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ktvql5</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0a7ljx8" sourceRef="Send" targetRef="Activity_AfterSend" />
+    <bpmn:endEvent id="Event_SendEnd" name="SendEnd">
+      <bpmn:incoming>Flow_0ktvql5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0ktvql5" sourceRef="Activity_AfterSend" targetRef="Event_SendEnd" />
+    <bpmn:sequenceFlow id="Flow_13sn2b2" name="path = &#39;Receive&#39;" sourceRef="Gateway_0d8vbql" targetRef="Receive" apex:sequence="40">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'Receive' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:receiveTask id="Receive" name="Receive" apex:type="basicApexMessage">
+      <bpmn:extensionElements>
+        <apex:messageName>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageName</apex:expression>
+        </apex:messageName>
+        <apex:correlationKey>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageKey</apex:expression>
+        </apex:correlationKey>
+        <apex:correlationValue>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageValue</apex:expression>
+        </apex:correlationValue>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_13sn2b2</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gx36mi</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:task id="Activity_AfterReceive" name="After Receive">
+      <bpmn:incoming>Flow_1gx36mi</bpmn:incoming>
+      <bpmn:outgoing>Flow_122voy1</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1gx36mi" sourceRef="Receive" targetRef="Activity_AfterReceive" />
+    <bpmn:endEvent id="Event_ReceiveEnd" name="ReceiveEnd">
+      <bpmn:incoming>Flow_122voy1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_122voy1" sourceRef="Activity_AfterReceive" targetRef="Event_ReceiveEnd" apex:sequence="10" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_A21a">
+      <bpmndi:BPMNShape id="Event_078jhcp_di" bpmnElement="Event_078jhcp">
+        <dc:Bounds x="162" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="168" y="495" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04w6zzy_di" bpmnElement="ITE">
+        <dc:Bounds x="642" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="651" y="495" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09ryfbc_di" bpmnElement="Activity_AfterITE">
+        <dc:Bounds x="740" y="430" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_023t4ki_di" bpmnElement="Event_ITEEnd">
+        <dc:Bounds x="902" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="902" y="495" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ius2or_di" bpmnElement="Activity_Before">
+        <dc:Bounds x="270" y="430" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0d8vbql_di" bpmnElement="Gateway_0d8vbql" isMarkerVisible="true">
+        <dc:Bounds x="415" y="445" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="374" y="433" width="31" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03abwhg_di" bpmnElement="ICE">
+        <dc:Bounds x="642" y="562" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="651" y="605" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0e91je8_di" bpmnElement="Activity_AfterICE">
+        <dc:Bounds x="740" y="540" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tsgkvz_di" bpmnElement="Event_ICEEnd">
+        <dc:Bounds x="902" y="562" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="901" y="605" width="38" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hxbrc5_di" bpmnElement="Send">
+        <dc:Bounds x="610" y="650" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mgopxu_di" bpmnElement="Activity_AfterSend">
+        <dc:Bounds x="760" y="650" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0pbphoc_di" bpmnElement="Event_SendEnd">
+        <dc:Bounds x="912" y="672" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="907" y="715" width="46" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ouv7wz_di" bpmnElement="Receive">
+        <dc:Bounds x="610" y="760" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12b9wva_di" bpmnElement="Activity_AfterReceive">
+        <dc:Bounds x="760" y="760" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0v2m07w_di" bpmnElement="Event_ReceiveEnd">
+        <dc:Bounds x="912" y="782" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="900" y="825" width="60" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_10cbwc9_di" bpmnElement="Flow_10cbwc9">
+        <di:waypoint x="198" y="470" />
+        <di:waypoint x="270" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1148c6v_di" bpmnElement="Flow_1148c6v">
+        <di:waypoint x="678" y="470" />
+        <di:waypoint x="740" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00v5eu3_di" bpmnElement="Flow_00v5eu3">
+        <di:waypoint x="840" y="470" />
+        <di:waypoint x="902" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b0bmnc_di" bpmnElement="Flow_0b0bmnc">
+        <di:waypoint x="370" y="470" />
+        <di:waypoint x="415" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u9rc68_di" bpmnElement="Flow_0u9rc68">
+        <di:waypoint x="465" y="470" />
+        <di:waypoint x="642" y="470" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="527" y="452" width="56" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10th9vn_di" bpmnElement="Flow_10th9vn">
+        <di:waypoint x="440" y="495" />
+        <di:waypoint x="440" y="580" />
+        <di:waypoint x="642" y="580" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="521" y="553" width="57" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16rs7dc_di" bpmnElement="Flow_16rs7dc">
+        <di:waypoint x="678" y="580" />
+        <di:waypoint x="740" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rlvoek_di" bpmnElement="Flow_0rlvoek">
+        <di:waypoint x="840" y="580" />
+        <di:waypoint x="902" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nhu01n_di" bpmnElement="Flow_1nhu01n">
+        <di:waypoint x="440" y="495" />
+        <di:waypoint x="440" y="690" />
+        <di:waypoint x="610" y="690" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="518" y="653" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0a7ljx8_di" bpmnElement="Flow_0a7ljx8">
+        <di:waypoint x="710" y="690" />
+        <di:waypoint x="760" y="690" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ktvql5_di" bpmnElement="Flow_0ktvql5">
+        <di:waypoint x="860" y="690" />
+        <di:waypoint x="912" y="690" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13sn2b2_di" bpmnElement="Flow_13sn2b2">
+        <di:waypoint x="440" y="495" />
+        <di:waypoint x="440" y="800" />
+        <di:waypoint x="610" y="800" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="491" y="773" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gx36mi_di" bpmnElement="Flow_1gx36mi">
+        <di:waypoint x="710" y="800" />
+        <di:waypoint x="760" y="800" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_122voy1_di" bpmnElement="Flow_122voy1">
+        <di:waypoint x="860" y="800" />
+        <di:waypoint x="912" y="800" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/models/A21c - Messageflow - bad endpoint_0.bpmn
+++ b/test/models/A21c - Messageflow - bad endpoint_0.bpmn
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:apex="https://flowsforapex.org" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1wzb475" targetNamespace="http://bpmn.io/schema/b" exporter="Flows for APEX" exporterVersion="23.1.0">
+  <bpmn:process id="Process_A21a" name="A21a - Basic MessageFlow" isExecutable="false" apex:manualInput="false">
+    <bpmn:startEvent id="Event_078jhcp" name="Start">
+      <bpmn:outgoing>Flow_10cbwc9</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_10cbwc9" sourceRef="Event_078jhcp" targetRef="Activity_Before" />
+    <bpmn:intermediateThrowEvent id="ITE" name="ITE" apex:type="basicApexMessage">
+      <bpmn:incoming>Flow_0u9rc68</bpmn:incoming>
+      <bpmn:outgoing>Flow_1148c6v</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_03dkrir">
+        <bpmn:extensionElements>
+          <apex:endpoint>
+            <apex:expressionType>static</apex:expressionType>
+            <apex:expression>remote</apex:expression>
+          </apex:endpoint>
+          <apex:messageName>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageName</apex:expression>
+          </apex:messageName>
+          <apex:correlationKey>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageKey</apex:expression>
+          </apex:correlationKey>
+          <apex:correlationValue>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageValue</apex:expression>
+          </apex:correlationValue>
+        </bpmn:extensionElements>
+      </bpmn:messageEventDefinition>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:task id="Activity_AfterITE" name="After ITE">
+      <bpmn:incoming>Flow_1148c6v</bpmn:incoming>
+      <bpmn:outgoing>Flow_00v5eu3</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1148c6v" sourceRef="ITE" targetRef="Activity_AfterITE" />
+    <bpmn:endEvent id="Event_ITEEnd" name="ITEEnd">
+      <bpmn:incoming>Flow_00v5eu3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_00v5eu3" sourceRef="Activity_AfterITE" targetRef="Event_ITEEnd" />
+    <bpmn:task id="Activity_Before" name="Before">
+      <bpmn:extensionElements>
+        <apex:beforeTask>
+          <apex:processVariable>
+            <apex:varSequence>0</apex:varSequence>
+            <apex:varName>messageKey</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>keya21a</apex:varExpression>
+          </apex:processVariable>
+          <apex:processVariable>
+            <apex:varSequence>1</apex:varSequence>
+            <apex:varName>messageName</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>MyMessage</apex:varExpression>
+          </apex:processVariable>
+          <apex:processVariable>
+            <apex:varSequence>2</apex:varSequence>
+            <apex:varName>messageValue</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>a21a</apex:varExpression>
+          </apex:processVariable>
+        </apex:beforeTask>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_10cbwc9</bpmn:incoming>
+      <bpmn:outgoing>Flow_0b0bmnc</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0b0bmnc" sourceRef="Activity_Before" targetRef="Gateway_0d8vbql" />
+    <bpmn:exclusiveGateway id="Gateway_0d8vbql" name="switch">
+      <bpmn:incoming>Flow_0b0bmnc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0u9rc68</bpmn:outgoing>
+      <bpmn:outgoing>Flow_10th9vn</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1nhu01n</bpmn:outgoing>
+      <bpmn:outgoing>Flow_13sn2b2</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0u9rc68" name="path = &#39;ITE&#39;" sourceRef="Gateway_0d8vbql" targetRef="ITE" apex:sequence="10">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'ITE' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_10th9vn" name="path = &#39;ICE&#39;" sourceRef="Gateway_0d8vbql" targetRef="ICE" apex:sequence="20">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'ICE' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:intermediateCatchEvent id="ICE" name="ICE" apex:type="basicApexMessage">
+      <bpmn:incoming>Flow_10th9vn</bpmn:incoming>
+      <bpmn:outgoing>Flow_16rs7dc</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0xcaexo">
+        <bpmn:extensionElements>
+          <apex:messageName>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageName</apex:expression>
+          </apex:messageName>
+          <apex:correlationKey>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageKey</apex:expression>
+          </apex:correlationKey>
+          <apex:correlationValue>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageValue</apex:expression>
+          </apex:correlationValue>
+        </bpmn:extensionElements>
+      </bpmn:messageEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:task id="Activity_AfterICE" name="After ICE">
+      <bpmn:incoming>Flow_16rs7dc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rlvoek</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_16rs7dc" sourceRef="ICE" targetRef="Activity_AfterICE" />
+    <bpmn:endEvent id="Event_ICEEnd" name="ICEEnd">
+      <bpmn:incoming>Flow_0rlvoek</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0rlvoek" sourceRef="Activity_AfterICE" targetRef="Event_ICEEnd" />
+    <bpmn:sequenceFlow id="Flow_1nhu01n" name="path = &#39;Send&#39;" sourceRef="Gateway_0d8vbql" targetRef="Send" apex:sequence="30">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'Send' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sendTask id="Send" name="Send" apex:type="basicApexMessage">
+      <bpmn:extensionElements>
+        <apex:endpoint>
+          <apex:expressionType>static</apex:expressionType>
+          <apex:expression>bad-endpoint</apex:expression>
+        </apex:endpoint>
+        <apex:messageName>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageName</apex:expression>
+        </apex:messageName>
+        <apex:correlationKey>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageKey</apex:expression>
+        </apex:correlationKey>
+        <apex:correlationValue>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageValue</apex:expression>
+        </apex:correlationValue>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1nhu01n</bpmn:incoming>
+      <bpmn:outgoing>Flow_0a7ljx8</bpmn:outgoing>
+    </bpmn:sendTask>
+    <bpmn:task id="Activity_AfterSend" name="After SendTask">
+      <bpmn:incoming>Flow_0a7ljx8</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ktvql5</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0a7ljx8" sourceRef="Send" targetRef="Activity_AfterSend" />
+    <bpmn:endEvent id="Event_SendEnd" name="SendEnd">
+      <bpmn:incoming>Flow_0ktvql5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0ktvql5" sourceRef="Activity_AfterSend" targetRef="Event_SendEnd" />
+    <bpmn:sequenceFlow id="Flow_13sn2b2" name="path = &#39;Receive&#39;" sourceRef="Gateway_0d8vbql" targetRef="Receive" apex:sequence="40">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'Receive' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:receiveTask id="Receive" name="Receive" apex:type="basicApexMessage">
+      <bpmn:extensionElements>
+        <apex:messageName>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageName</apex:expression>
+        </apex:messageName>
+        <apex:correlationKey>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageKey</apex:expression>
+        </apex:correlationKey>
+        <apex:correlationValue>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageValue</apex:expression>
+        </apex:correlationValue>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_13sn2b2</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gx36mi</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:task id="Activity_AfterReceive" name="After Receive">
+      <bpmn:incoming>Flow_1gx36mi</bpmn:incoming>
+      <bpmn:outgoing>Flow_122voy1</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1gx36mi" sourceRef="Receive" targetRef="Activity_AfterReceive" />
+    <bpmn:endEvent id="Event_ReceiveEnd" name="ReceiveEnd">
+      <bpmn:incoming>Flow_122voy1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_122voy1" sourceRef="Activity_AfterReceive" targetRef="Event_ReceiveEnd" apex:sequence="10" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_A21a">
+      <bpmndi:BPMNShape id="Event_078jhcp_di" bpmnElement="Event_078jhcp">
+        <dc:Bounds x="162" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="168" y="495" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04w6zzy_di" bpmnElement="ITE">
+        <dc:Bounds x="642" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="651" y="495" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09ryfbc_di" bpmnElement="Activity_AfterITE">
+        <dc:Bounds x="740" y="430" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_023t4ki_di" bpmnElement="Event_ITEEnd">
+        <dc:Bounds x="902" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="902" y="495" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ius2or_di" bpmnElement="Activity_Before">
+        <dc:Bounds x="270" y="430" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0d8vbql_di" bpmnElement="Gateway_0d8vbql" isMarkerVisible="true">
+        <dc:Bounds x="415" y="445" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="374" y="433" width="31" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03abwhg_di" bpmnElement="ICE">
+        <dc:Bounds x="642" y="562" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="651" y="605" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0e91je8_di" bpmnElement="Activity_AfterICE">
+        <dc:Bounds x="740" y="540" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tsgkvz_di" bpmnElement="Event_ICEEnd">
+        <dc:Bounds x="902" y="562" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="901" y="605" width="38" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hxbrc5_di" bpmnElement="Send">
+        <dc:Bounds x="610" y="650" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mgopxu_di" bpmnElement="Activity_AfterSend">
+        <dc:Bounds x="760" y="650" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0pbphoc_di" bpmnElement="Event_SendEnd">
+        <dc:Bounds x="912" y="672" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="907" y="715" width="46" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ouv7wz_di" bpmnElement="Receive">
+        <dc:Bounds x="610" y="760" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12b9wva_di" bpmnElement="Activity_AfterReceive">
+        <dc:Bounds x="760" y="760" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0v2m07w_di" bpmnElement="Event_ReceiveEnd">
+        <dc:Bounds x="912" y="782" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="900" y="825" width="60" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_10cbwc9_di" bpmnElement="Flow_10cbwc9">
+        <di:waypoint x="198" y="470" />
+        <di:waypoint x="270" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1148c6v_di" bpmnElement="Flow_1148c6v">
+        <di:waypoint x="678" y="470" />
+        <di:waypoint x="740" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00v5eu3_di" bpmnElement="Flow_00v5eu3">
+        <di:waypoint x="840" y="470" />
+        <di:waypoint x="902" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b0bmnc_di" bpmnElement="Flow_0b0bmnc">
+        <di:waypoint x="370" y="470" />
+        <di:waypoint x="415" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u9rc68_di" bpmnElement="Flow_0u9rc68">
+        <di:waypoint x="465" y="470" />
+        <di:waypoint x="642" y="470" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="527" y="452" width="56" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10th9vn_di" bpmnElement="Flow_10th9vn">
+        <di:waypoint x="440" y="495" />
+        <di:waypoint x="440" y="580" />
+        <di:waypoint x="642" y="580" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="521" y="553" width="57" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16rs7dc_di" bpmnElement="Flow_16rs7dc">
+        <di:waypoint x="678" y="580" />
+        <di:waypoint x="740" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rlvoek_di" bpmnElement="Flow_0rlvoek">
+        <di:waypoint x="840" y="580" />
+        <di:waypoint x="902" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nhu01n_di" bpmnElement="Flow_1nhu01n">
+        <di:waypoint x="440" y="495" />
+        <di:waypoint x="440" y="690" />
+        <di:waypoint x="610" y="690" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="518" y="653" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0a7ljx8_di" bpmnElement="Flow_0a7ljx8">
+        <di:waypoint x="710" y="690" />
+        <di:waypoint x="760" y="690" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ktvql5_di" bpmnElement="Flow_0ktvql5">
+        <di:waypoint x="860" y="690" />
+        <di:waypoint x="912" y="690" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13sn2b2_di" bpmnElement="Flow_13sn2b2">
+        <di:waypoint x="440" y="495" />
+        <di:waypoint x="440" y="800" />
+        <di:waypoint x="610" y="800" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="491" y="773" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gx36mi_di" bpmnElement="Flow_1gx36mi">
+        <di:waypoint x="710" y="800" />
+        <di:waypoint x="760" y="800" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_122voy1_di" bpmnElement="Flow_122voy1">
+        <di:waypoint x="860" y="800" />
+        <di:waypoint x="912" y="800" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/models/A21d - Messageflow - basics - Collaboration_0.bpmn
+++ b/test/models/A21d - Messageflow - basics - Collaboration_0.bpmn
@@ -1,0 +1,390 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:apex="https://flowsforapex.org" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1wzb475" targetNamespace="http://bpmn.io/schema/b" exporter="Flows for APEX" exporterVersion="23.1.0">
+  <bpmn:collaboration id="Collaboration_0ce43gg">
+    <bpmn:participant id="Participant_058cg4l" name="MyCollaboration" processRef="Process_A21a" />
+    <bpmn:participant id="Participant_1wz9u0e" name="OtherProcess" />
+    <bpmn:messageFlow id="Flow_0w016gn" sourceRef="ITE" targetRef="Participant_1wz9u0e" />
+    <bpmn:messageFlow id="Flow_1s5tr8b" sourceRef="Participant_1wz9u0e" targetRef="ICE" />
+    <bpmn:messageFlow id="Flow_0el2kvi" sourceRef="Send" targetRef="Participant_1wz9u0e" />
+    <bpmn:messageFlow id="Flow_0jw2fjs" sourceRef="Participant_1wz9u0e" targetRef="Receive" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_A21a" name="A21a - Basic MessageFlow" isExecutable="false">
+    <bpmn:startEvent id="Event_078jhcp" name="Start">
+      <bpmn:outgoing>Flow_10cbwc9</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="ITE" name="ITE" apex:type="basicApexMessage">
+      <bpmn:incoming>Flow_0u9rc68</bpmn:incoming>
+      <bpmn:outgoing>Flow_1148c6v</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_03dkrir">
+        <bpmn:extensionElements>
+          <apex:endpoint>
+            <apex:expressionType>static</apex:expressionType>
+            <apex:expression>local</apex:expression>
+          </apex:endpoint>
+          <apex:messageName>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageName</apex:expression>
+          </apex:messageName>
+          <apex:correlationKey>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageKey</apex:expression>
+          </apex:correlationKey>
+          <apex:correlationValue>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageValue</apex:expression>
+          </apex:correlationValue>
+          <apex:payload>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messagePayload</apex:expression>
+          </apex:payload>
+        </bpmn:extensionElements>
+      </bpmn:messageEventDefinition>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:task id="Activity_AfterITE" name="After ITE">
+      <bpmn:incoming>Flow_1148c6v</bpmn:incoming>
+      <bpmn:outgoing>Flow_00v5eu3</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="Event_ITEEnd" name="ITEEnd">
+      <bpmn:incoming>Flow_00v5eu3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="Activity_Before" name="Before">
+      <bpmn:extensionElements>
+        <apex:beforeTask>
+          <apex:processVariable>
+            <apex:varSequence>0</apex:varSequence>
+            <apex:varName>messageKey</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>keya21a</apex:varExpression>
+          </apex:processVariable>
+          <apex:processVariable>
+            <apex:varSequence>1</apex:varSequence>
+            <apex:varName>messageName</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>MyMessage</apex:varExpression>
+          </apex:processVariable>
+          <apex:processVariable>
+            <apex:varSequence>2</apex:varSequence>
+            <apex:varName>messageValue</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>a21a</apex:varExpression>
+          </apex:processVariable>
+          <apex:processVariable>
+            <apex:varSequence>3</apex:varSequence>
+            <apex:varName>messagePayload</apex:varName>
+            <apex:varDataType>VARCHAR2</apex:varDataType>
+            <apex:varExpressionType>static</apex:varExpressionType>
+            <apex:varExpression>originalPayload</apex:varExpression>
+          </apex:processVariable>
+        </apex:beforeTask>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_10cbwc9</bpmn:incoming>
+      <bpmn:outgoing>Flow_0b0bmnc</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:exclusiveGateway id="Gateway_0d8vbql" name="switch">
+      <bpmn:incoming>Flow_0b0bmnc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0u9rc68</bpmn:outgoing>
+      <bpmn:outgoing>Flow_10th9vn</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1nhu01n</bpmn:outgoing>
+      <bpmn:outgoing>Flow_13sn2b2</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="Activity_AfterICE" name="After ICE">
+      <bpmn:incoming>Flow_16rs7dc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rlvoek</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="Event_ICEEnd" name="ICEEnd">
+      <bpmn:incoming>Flow_0rlvoek</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="Activity_AfterSend" name="After SendTask">
+      <bpmn:incoming>Flow_0a7ljx8</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ktvql5</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="Event_SendEnd" name="SendEnd">
+      <bpmn:incoming>Flow_0ktvql5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="Activity_AfterReceive" name="After Receive">
+      <bpmn:incoming>Flow_1gx36mi</bpmn:incoming>
+      <bpmn:outgoing>Flow_122voy1</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="Event_ReceiveEnd" name="ReceiveEnd">
+      <bpmn:incoming>Flow_122voy1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_10cbwc9" sourceRef="Event_078jhcp" targetRef="Activity_Before" />
+    <bpmn:sequenceFlow id="Flow_0u9rc68" name="path = &#39;ITE&#39;" sourceRef="Gateway_0d8vbql" targetRef="ITE" apex:sequence="10">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'ITE' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1148c6v" sourceRef="ITE" targetRef="Activity_AfterITE" />
+    <bpmn:sequenceFlow id="Flow_00v5eu3" sourceRef="Activity_AfterITE" targetRef="Event_ITEEnd" />
+    <bpmn:sequenceFlow id="Flow_0b0bmnc" sourceRef="Activity_Before" targetRef="Gateway_0d8vbql" />
+    <bpmn:sequenceFlow id="Flow_10th9vn" name="path = &#39;ICE&#39;" sourceRef="Gateway_0d8vbql" targetRef="ICE" apex:sequence="20">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'ICE' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1nhu01n" name="path = &#39;Send&#39;" sourceRef="Gateway_0d8vbql" targetRef="Send" apex:sequence="30">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'Send' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_13sn2b2" name="path = &#39;Receive&#39;" sourceRef="Gateway_0d8vbql" targetRef="Receive" apex:sequence="40">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="plsqlFunctionBody">case :F4A$path
+ when 'Receive' then return true;
+else return false;
+end case;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_16rs7dc" sourceRef="ICE" targetRef="Activity_AfterICE" />
+    <bpmn:sequenceFlow id="Flow_0rlvoek" sourceRef="Activity_AfterICE" targetRef="Event_ICEEnd" />
+    <bpmn:sequenceFlow id="Flow_0a7ljx8" sourceRef="Send" targetRef="Activity_AfterSend" />
+    <bpmn:sequenceFlow id="Flow_0ktvql5" sourceRef="Activity_AfterSend" targetRef="Event_SendEnd" />
+    <bpmn:sequenceFlow id="Flow_1gx36mi" sourceRef="Receive" targetRef="Activity_AfterReceive" />
+    <bpmn:sequenceFlow id="Flow_122voy1" sourceRef="Activity_AfterReceive" targetRef="Event_ReceiveEnd" apex:sequence="10" />
+    <bpmn:sendTask id="Send" name="Send" apex:type="basicApexMessage">
+      <bpmn:extensionElements>
+        <apex:endpoint>
+          <apex:expressionType>static</apex:expressionType>
+          <apex:expression>local</apex:expression>
+        </apex:endpoint>
+        <apex:messageName>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageName</apex:expression>
+        </apex:messageName>
+        <apex:correlationKey>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageKey</apex:expression>
+        </apex:correlationKey>
+        <apex:correlationValue>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageValue</apex:expression>
+        </apex:correlationValue>
+        <apex:payload>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messagePayload</apex:expression>
+        </apex:payload>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1nhu01n</bpmn:incoming>
+      <bpmn:outgoing>Flow_0a7ljx8</bpmn:outgoing>
+    </bpmn:sendTask>
+    <bpmn:intermediateCatchEvent id="ICE" name="ICE" apex:type="basicApexMessage">
+      <bpmn:incoming>Flow_10th9vn</bpmn:incoming>
+      <bpmn:outgoing>Flow_16rs7dc</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0xcaexo">
+        <bpmn:extensionElements>
+          <apex:messageName>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageName</apex:expression>
+          </apex:messageName>
+          <apex:correlationKey>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageKey</apex:expression>
+          </apex:correlationKey>
+          <apex:correlationValue>
+            <apex:expressionType>processVariable</apex:expressionType>
+            <apex:expression>messageValue</apex:expression>
+          </apex:correlationValue>
+          <apex:payloadVariable>returnPayload</apex:payloadVariable>
+        </bpmn:extensionElements>
+      </bpmn:messageEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:receiveTask id="Receive" name="Receive" apex:type="basicApexMessage">
+      <bpmn:extensionElements>
+        <apex:messageName>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageName</apex:expression>
+        </apex:messageName>
+        <apex:correlationKey>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageKey</apex:expression>
+        </apex:correlationKey>
+        <apex:correlationValue>
+          <apex:expressionType>processVariable</apex:expressionType>
+          <apex:expression>messageValue</apex:expression>
+        </apex:correlationValue>
+        <apex:payloadVariable>returnPayload</apex:payloadVariable>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_13sn2b2</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gx36mi</bpmn:outgoing>
+    </bpmn:receiveTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0ce43gg">
+      <bpmndi:BPMNShape id="Participant_058cg4l_di" bpmnElement="Participant_058cg4l" isHorizontal="true">
+        <dc:Bounds x="110" y="410" width="860" height="450" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_078jhcp_di" bpmnElement="Event_078jhcp">
+        <dc:Bounds x="162" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="168" y="495" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04w6zzy_di" bpmnElement="ITE">
+        <dc:Bounds x="642" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="651" y="495" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09ryfbc_di" bpmnElement="Activity_AfterITE">
+        <dc:Bounds x="740" y="430" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_023t4ki_di" bpmnElement="Event_ITEEnd">
+        <dc:Bounds x="902" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="902" y="495" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ius2or_di" bpmnElement="Activity_Before">
+        <dc:Bounds x="270" y="430" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0d8vbql_di" bpmnElement="Gateway_0d8vbql" isMarkerVisible="true">
+        <dc:Bounds x="415" y="445" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="374" y="433" width="31" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0e91je8_di" bpmnElement="Activity_AfterICE">
+        <dc:Bounds x="740" y="540" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tsgkvz_di" bpmnElement="Event_ICEEnd">
+        <dc:Bounds x="902" y="562" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="901" y="605" width="38" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mgopxu_di" bpmnElement="Activity_AfterSend">
+        <dc:Bounds x="760" y="650" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0pbphoc_di" bpmnElement="Event_SendEnd">
+        <dc:Bounds x="912" y="672" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="907" y="715" width="46" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12b9wva_di" bpmnElement="Activity_AfterReceive">
+        <dc:Bounds x="760" y="760" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0v2m07w_di" bpmnElement="Event_ReceiveEnd">
+        <dc:Bounds x="912" y="782" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="900" y="825" width="60" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hxbrc5_di" bpmnElement="Send">
+        <dc:Bounds x="550" y="650" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03abwhg_di" bpmnElement="ICE">
+        <dc:Bounds x="602" y="562" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="611" y="605" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ouv7wz_di" bpmnElement="Receive">
+        <dc:Bounds x="480" y="760" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_10cbwc9_di" bpmnElement="Flow_10cbwc9">
+        <di:waypoint x="198" y="470" />
+        <di:waypoint x="270" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u9rc68_di" bpmnElement="Flow_0u9rc68">
+        <di:waypoint x="465" y="470" />
+        <di:waypoint x="642" y="470" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="462" y="452" width="56" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1148c6v_di" bpmnElement="Flow_1148c6v">
+        <di:waypoint x="678" y="470" />
+        <di:waypoint x="740" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00v5eu3_di" bpmnElement="Flow_00v5eu3">
+        <di:waypoint x="840" y="470" />
+        <di:waypoint x="902" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b0bmnc_di" bpmnElement="Flow_0b0bmnc">
+        <di:waypoint x="370" y="470" />
+        <di:waypoint x="415" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10th9vn_di" bpmnElement="Flow_10th9vn">
+        <di:waypoint x="440" y="495" />
+        <di:waypoint x="440" y="580" />
+        <di:waypoint x="602" y="580" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="450" y="553" width="57" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nhu01n_di" bpmnElement="Flow_1nhu01n">
+        <di:waypoint x="440" y="495" />
+        <di:waypoint x="440" y="690" />
+        <di:waypoint x="550" y="690" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="447" y="653" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13sn2b2_di" bpmnElement="Flow_13sn2b2">
+        <di:waypoint x="440" y="495" />
+        <di:waypoint x="440" y="800" />
+        <di:waypoint x="480" y="800" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="361" y="723" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16rs7dc_di" bpmnElement="Flow_16rs7dc">
+        <di:waypoint x="638" y="580" />
+        <di:waypoint x="740" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rlvoek_di" bpmnElement="Flow_0rlvoek">
+        <di:waypoint x="840" y="580" />
+        <di:waypoint x="902" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0a7ljx8_di" bpmnElement="Flow_0a7ljx8">
+        <di:waypoint x="650" y="690" />
+        <di:waypoint x="760" y="690" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ktvql5_di" bpmnElement="Flow_0ktvql5">
+        <di:waypoint x="860" y="690" />
+        <di:waypoint x="912" y="690" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gx36mi_di" bpmnElement="Flow_1gx36mi">
+        <di:waypoint x="580" y="800" />
+        <di:waypoint x="760" y="800" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_122voy1_di" bpmnElement="Flow_122voy1">
+        <di:waypoint x="860" y="800" />
+        <di:waypoint x="912" y="800" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_13xc0xe_di" bpmnElement="Participant_1wz9u0e" isHorizontal="true">
+        <dc:Bounds x="110" y="110" width="860" height="60" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0w016gn_di" bpmnElement="Flow_0w016gn">
+        <di:waypoint x="660" y="452" />
+        <di:waypoint x="660" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1s5tr8b_di" bpmnElement="Flow_1s5tr8b">
+        <di:waypoint x="620" y="170" />
+        <di:waypoint x="620" y="562" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0el2kvi_di" bpmnElement="Flow_0el2kvi">
+        <di:waypoint x="580" y="650" />
+        <di:waypoint x="580" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jw2fjs_di" bpmnElement="Flow_0jw2fjs">
+        <di:waypoint x="530" y="170" />
+        <di:waypoint x="530" y="760" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/models/A21e - MessageFlow basics - Subscription Cancellation_0.bpmn
+++ b/test/models/A21e - MessageFlow basics - Subscription Cancellation_0.bpmn
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:apex="https://flowsforapex.org" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1wzb475" targetNamespace="http://bpmn.io/schema/b" exporter="Flows for APEX" exporterVersion="23.1.0">
+  <bpmn:process id="Process_A21e" name="A21e - Subscuption Cancellation" isExecutable="true" apex:manualInput="false">
+    <bpmn:documentation>Idea is to set up 2 levels of subprocesses.  The inner subprocess creates a message subscription.
+Then by moving forward on `Before ErrorEnd` this will cause the top sub process to terminate, which includes clering up the inner subprocess.  Then check if the subscription gets cleared up as part of moving onto the Error BE path.</bpmn:documentation>
+    <bpmn:startEvent id="Event_Start" name="Start">
+      <bpmn:outgoing>Flow_13ep45s</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_BeforeTest" name="BeforeTest">
+      <bpmn:incoming>Flow_13ep45s</bpmn:incoming>
+      <bpmn:outgoing>Flow_0dn450i</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_13ep45s" sourceRef="Event_Start" targetRef="Activity_BeforeTest" />
+    <bpmn:sequenceFlow id="Flow_0dn450i" sourceRef="Activity_BeforeTest" targetRef="Activity_A" />
+    <bpmn:subProcess id="Activity_A" name="A">
+      <bpmn:incoming>Flow_0dn450i</bpmn:incoming>
+      <bpmn:outgoing>Flow_0bbu5x5</bpmn:outgoing>
+      <bpmn:startEvent id="Event_AStart" name="AStart">
+        <bpmn:outgoing>Flow_1ppe5c5</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1ppe5c5" sourceRef="Event_AStart" targetRef="Gateway_ASplit" />
+      <bpmn:parallelGateway id="Gateway_ASplit" name="ASplit">
+        <bpmn:incoming>Flow_1ppe5c5</bpmn:incoming>
+        <bpmn:outgoing>Flow_0nvljn5</bpmn:outgoing>
+        <bpmn:outgoing>Flow_16q4zi4</bpmn:outgoing>
+      </bpmn:parallelGateway>
+      <bpmn:sequenceFlow id="Flow_0nvljn5" sourceRef="Gateway_ASplit" targetRef="Activity_A1" />
+      <bpmn:subProcess id="Activity_A1" name="A1">
+        <bpmn:incoming>Flow_0nvljn5</bpmn:incoming>
+        <bpmn:outgoing>Flow_039urxm</bpmn:outgoing>
+        <bpmn:startEvent id="Event_A1Start" name="A1Start">
+          <bpmn:outgoing>Flow_0792br6</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:sequenceFlow id="Flow_0792br6" sourceRef="Event_A1Start" targetRef="Activity_Receive" />
+        <bpmn:endEvent id="Event_A1End" name="A1End">
+          <bpmn:incoming>Flow_0qnnm8b</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_0qnnm8b" sourceRef="Activity_Receive" targetRef="Event_A1End" />
+        <bpmn:receiveTask id="Activity_Receive" name="Receive" apex:type="basicApexMessage">
+          <bpmn:extensionElements>
+            <apex:messageName>
+              <apex:expressionType>sqlQuerySingle</apex:expressionType>
+              <apex:expression>select 'MyMessage' from dual</apex:expression>
+            </apex:messageName>
+            <apex:correlationKey>
+              <apex:expressionType>sqlQuerySingle</apex:expressionType>
+              <apex:expression>select 'myKey' from dual;</apex:expression>
+            </apex:correlationKey>
+            <apex:correlationValue>
+              <apex:expressionType>sqlQuerySingle</apex:expressionType>
+              <apex:expression>select 'myValue' from dual;</apex:expression>
+            </apex:correlationValue>
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_0792br6</bpmn:incoming>
+          <bpmn:outgoing>Flow_0qnnm8b</bpmn:outgoing>
+        </bpmn:receiveTask>
+      </bpmn:subProcess>
+      <bpmn:task id="Activity_BeforeErrorEnd" name="Before ErrorEnd">
+        <bpmn:incoming>Flow_16q4zi4</bpmn:incoming>
+        <bpmn:outgoing>Flow_1gbmb05</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_16q4zi4" sourceRef="Gateway_ASplit" targetRef="Activity_BeforeErrorEnd" />
+      <bpmn:sequenceFlow id="Flow_1gbmb05" sourceRef="Activity_BeforeErrorEnd" targetRef="Event_AErrorEnd" />
+      <bpmn:endEvent id="Event_AErrorEnd" name="AErrorEnd">
+        <bpmn:incoming>Flow_1gbmb05</bpmn:incoming>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_14y3vwk" />
+      </bpmn:endEvent>
+      <bpmn:endEvent id="Event_AEnd" name="AEnd">
+        <bpmn:incoming>Flow_039urxm</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_039urxm" sourceRef="Activity_A1" targetRef="Event_AEnd" />
+    </bpmn:subProcess>
+    <bpmn:task id="Activity_AfterErrorBE" name="After ErrorBE">
+      <bpmn:incoming>Flow_1cy7btm</bpmn:incoming>
+      <bpmn:outgoing>Flow_1v0kemo</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1cy7btm" sourceRef="Event_ErrorBE" targetRef="Activity_AfterErrorBE" />
+    <bpmn:boundaryEvent id="Event_ErrorBE" name="ErrorBE" attachedToRef="Activity_A">
+      <bpmn:outgoing>Flow_1cy7btm</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0s2weiz" />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="Event_MainErrorEnd" name="MainErrorEnd">
+      <bpmn:incoming>Flow_1v0kemo</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1v0kemo" sourceRef="Activity_AfterErrorBE" targetRef="Event_MainErrorEnd" />
+    <bpmn:endEvent id="Event_End" name="End">
+      <bpmn:incoming>Flow_0bbu5x5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0bbu5x5" sourceRef="Activity_A" targetRef="Event_End" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_A21e">
+      <bpmndi:BPMNShape id="Event_0nuy8pa_di" bpmnElement="Event_Start">
+        <dc:Bounds x="232" y="352" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="238" y="395" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1efs7pb_di" bpmnElement="Activity_BeforeTest">
+        <dc:Bounds x="320" y="330" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09iy27l_di" bpmnElement="Activity_AfterErrorBE">
+        <dc:Bounds x="1080" y="820" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1fu6lp8_di" bpmnElement="Event_MainErrorEnd">
+        <dc:Bounds x="1242" y="842" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1226" y="885" width="68" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_196leob_di" bpmnElement="Event_End">
+        <dc:Bounds x="1672" y="482" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1680" y="525" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_121d9t6_di" bpmnElement="Activity_A" isExpanded="true">
+        <dc:Bounds x="550" y="220" width="990" height="560" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0bbtyfz_di" bpmnElement="Event_AStart">
+        <dc:Bounds x="592" y="362" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="595" y="405" width="31" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0sb697u_di" bpmnElement="Gateway_ASplit">
+        <dc:Bounds x="685" y="355" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="696" y="325" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_17dh8eu_di" bpmnElement="Activity_BeforeErrorEnd">
+        <dc:Bounds x="820" y="570" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0184h35_di" bpmnElement="Event_AErrorEnd">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1004" y="635" width="52" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0wh4gae_di" bpmnElement="Event_AEnd">
+        <dc:Bounds x="1282" y="422" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1287" y="465" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0gavako_di" bpmnElement="Activity_A1" isExpanded="true">
+        <dc:Bounds x="830" y="340" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0u8f0wi_di" bpmnElement="Event_A1Start">
+        <dc:Bounds x="870.3333333333334" y="402" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="870" y="445" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0kyc29y_di" bpmnElement="Event_A1End">
+        <dc:Bounds x="1122" y="402" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1124" y="445" width="33" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12u1akr_di" bpmnElement="Activity_Receive">
+        <dc:Bounds x="960" y="380" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0792br6_di" bpmnElement="Flow_0792br6">
+        <di:waypoint x="906" y="420" />
+        <di:waypoint x="960" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qnnm8b_di" bpmnElement="Flow_0qnnm8b">
+        <di:waypoint x="1060" y="420" />
+        <di:waypoint x="1122" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ppe5c5_di" bpmnElement="Flow_1ppe5c5">
+        <di:waypoint x="628" y="380" />
+        <di:waypoint x="685" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nvljn5_di" bpmnElement="Flow_0nvljn5">
+        <di:waypoint x="735" y="380" />
+        <di:waypoint x="830" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16q4zi4_di" bpmnElement="Flow_16q4zi4">
+        <di:waypoint x="710" y="405" />
+        <di:waypoint x="710" y="610" />
+        <di:waypoint x="820" y="610" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gbmb05_di" bpmnElement="Flow_1gbmb05">
+        <di:waypoint x="920" y="610" />
+        <di:waypoint x="1012" y="610" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_039urxm_di" bpmnElement="Flow_039urxm">
+        <di:waypoint x="1180" y="440" />
+        <di:waypoint x="1282" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0igxy3x_di" bpmnElement="Event_ErrorBE">
+        <dc:Bounds x="987" y="762" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="986" y="805" width="40" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_13ep45s_di" bpmnElement="Flow_13ep45s">
+        <di:waypoint x="268" y="370" />
+        <di:waypoint x="320" y="370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dn450i_di" bpmnElement="Flow_0dn450i">
+        <di:waypoint x="420" y="370" />
+        <di:waypoint x="550" y="370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1cy7btm_di" bpmnElement="Flow_1cy7btm">
+        <di:waypoint x="1005" y="798" />
+        <di:waypoint x="1005" y="860" />
+        <di:waypoint x="1080" y="860" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1v0kemo_di" bpmnElement="Flow_1v0kemo">
+        <di:waypoint x="1180" y="860" />
+        <di:waypoint x="1242" y="860" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bbu5x5_di" bpmnElement="Flow_0bbu5x5">
+        <di:waypoint x="1540" y="500" />
+        <di:waypoint x="1672" y="500" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/models/A21f - Basic Messageflow - EBG_0.bpmn
+++ b/test/models/A21f - Basic Messageflow - EBG_0.bpmn
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:apex="https://flowsforapex.org" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1wzb475" targetNamespace="http://bpmn.io/schema/b" exporter="Flows for APEX" exporterVersion="23.1.0">
+  <bpmn:process id="Process_A21f" name="A21f MessageFlow and Event Based Gateways" isExecutable="true" apex:manualInput="false">
+    <bpmn:startEvent id="Event_Start" name="Start">
+      <bpmn:outgoing>Flow_03sw70g</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_BeforeGateway" name="BeforeGateway">
+      <bpmn:incoming>Flow_03sw70g</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ey34y6</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_03sw70g" sourceRef="Event_Start" targetRef="Activity_BeforeGateway" />
+    <bpmn:sequenceFlow id="Flow_1ey34y6" sourceRef="Activity_BeforeGateway" targetRef="Gateway_1wgstis" />
+    <bpmn:eventBasedGateway id="Gateway_1wgstis" name="EBG">
+      <bpmn:incoming>Flow_1ey34y6</bpmn:incoming>
+      <bpmn:outgoing>Flow_07vgiw0</bpmn:outgoing>
+      <bpmn:outgoing>Flow_13515ga</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1siv5zn</bpmn:outgoing>
+      <bpmn:outgoing>Flow_009p1i1</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:receiveTask id="Activity_Receive" name="Receive" apex:type="basicApexMessage">
+      <bpmn:extensionElements>
+        <apex:messageName>
+          <apex:expressionType>plsqlRawExpression</apex:expressionType>
+          <apex:expression>'MyMessage'</apex:expression>
+        </apex:messageName>
+        <apex:correlationKey>
+          <apex:expressionType>plsqlRawExpression</apex:expressionType>
+          <apex:expression>'Processor'</apex:expression>
+        </apex:correlationKey>
+        <apex:correlationValue>
+          <apex:expressionType>plsqlRawExpression</apex:expressionType>
+          <apex:expression>'Receive'</apex:expression>
+        </apex:correlationValue>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_07vgiw0</bpmn:incoming>
+      <bpmn:outgoing>Flow_0z7lv2k</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:sequenceFlow id="Flow_07vgiw0" sourceRef="Gateway_1wgstis" targetRef="Activity_Receive" />
+    <bpmn:intermediateCatchEvent id="Event_ICEMessage1" name="ICEMessage1" apex:type="basicApexMessage">
+      <bpmn:incoming>Flow_13515ga</bpmn:incoming>
+      <bpmn:outgoing>Flow_0nrp589</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0mkhhdo">
+        <bpmn:extensionElements>
+          <apex:messageName>
+            <apex:expressionType>plsqlRawExpression</apex:expressionType>
+            <apex:expression>'MyMessage'</apex:expression>
+          </apex:messageName>
+          <apex:correlationKey>
+            <apex:expressionType>plsqlRawExpression</apex:expressionType>
+            <apex:expression>'Processor'</apex:expression>
+          </apex:correlationKey>
+          <apex:correlationValue>
+            <apex:expressionType>plsqlRawExpression</apex:expressionType>
+            <apex:expression>'ICE'||'Message1'</apex:expression>
+          </apex:correlationValue>
+        </bpmn:extensionElements>
+      </bpmn:messageEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_13515ga" sourceRef="Gateway_1wgstis" targetRef="Event_ICEMessage1" />
+    <bpmn:intermediateCatchEvent id="Event_ICEMessage2" name="ICEMessage2" apex:type="basicApexMessage">
+      <bpmn:incoming>Flow_1siv5zn</bpmn:incoming>
+      <bpmn:outgoing>Flow_0aufudp</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0yqmzvh">
+        <bpmn:extensionElements>
+          <apex:messageName>
+            <apex:expressionType>plsqlRawExpression</apex:expressionType>
+            <apex:expression>'MyMessage'</apex:expression>
+          </apex:messageName>
+          <apex:correlationKey>
+            <apex:expressionType>plsqlRawExpression</apex:expressionType>
+            <apex:expression>'Processor'</apex:expression>
+          </apex:correlationKey>
+          <apex:correlationValue>
+            <apex:expressionType>plsqlRawExpression</apex:expressionType>
+            <apex:expression>'ICE'||'Message2'</apex:expression>
+          </apex:correlationValue>
+        </bpmn:extensionElements>
+      </bpmn:messageEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_1siv5zn" sourceRef="Gateway_1wgstis" targetRef="Event_ICEMessage2" />
+    <bpmn:intermediateCatchEvent id="Event_ICETimer" name="ICETimer">
+      <bpmn:incoming>Flow_009p1i1</bpmn:incoming>
+      <bpmn:outgoing>Flow_1yh856b</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1kq124i" apex:timerType="oracleDuration">
+        <bpmn:extensionElements>
+          <apex:oracleDuration>
+            <apex:intervalDS>000 00:00:05</apex:intervalDS>
+          </apex:oracleDuration>
+        </bpmn:extensionElements>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_009p1i1" sourceRef="Gateway_1wgstis" targetRef="Event_ICETimer" />
+    <bpmn:task id="Activity_After_Receive" name="After Receive">
+      <bpmn:incoming>Flow_0z7lv2k</bpmn:incoming>
+      <bpmn:outgoing>Flow_0lbe0co</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0z7lv2k" sourceRef="Activity_Receive" targetRef="Activity_After_Receive" />
+    <bpmn:task id="Activity_After_ICEMessage1" name="After ICEMessage1">
+      <bpmn:incoming>Flow_0nrp589</bpmn:incoming>
+      <bpmn:outgoing>Flow_0bexo21</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0nrp589" sourceRef="Event_ICEMessage1" targetRef="Activity_After_ICEMessage1" />
+    <bpmn:task id="Activity_After_ICEMessage2" name="After ICEMessage2">
+      <bpmn:incoming>Flow_0aufudp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1j37tji</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0aufudp" sourceRef="Event_ICEMessage2" targetRef="Activity_After_ICEMessage2" />
+    <bpmn:task id="Activity_After_ICETimer" name="After ICETimer">
+      <bpmn:incoming>Flow_1yh856b</bpmn:incoming>
+      <bpmn:outgoing>Flow_0fp8uvo</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1yh856b" sourceRef="Event_ICETimer" targetRef="Activity_After_ICETimer" />
+    <bpmn:endEvent id="Event_ICETimerEnd" name="ICETimerEnd">
+      <bpmn:incoming>Flow_0fp8uvo</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0fp8uvo" sourceRef="Activity_After_ICETimer" targetRef="Event_ICETimerEnd" apex:sequence="10" />
+    <bpmn:endEvent id="Event_ICEMessage2End" name="ICEMessage2End">
+      <bpmn:incoming>Flow_1j37tji</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1j37tji" sourceRef="Activity_After_ICEMessage2" targetRef="Event_ICEMessage2End" />
+    <bpmn:endEvent id="Event_ICEMessage1End" name="ICEMessage1End">
+      <bpmn:incoming>Flow_0bexo21</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0bexo21" sourceRef="Activity_After_ICEMessage1" targetRef="Event_ICEMessage1End" />
+    <bpmn:endEvent id="Event_ReceiveEnd" name="ReceiveEnd">
+      <bpmn:incoming>Flow_0lbe0co</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0lbe0co" sourceRef="Activity_After_Receive" targetRef="Event_ReceiveEnd" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_A21f">
+      <bpmndi:BPMNShape id="Event_1md9c7x_di" bpmnElement="Event_Start">
+        <dc:Bounds x="332" y="442" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="338" y="485" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d1xskx_di" bpmnElement="Activity_BeforeGateway">
+        <dc:Bounds x="420" y="420" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0z1agiw_di" bpmnElement="Gateway_1wgstis">
+        <dc:Bounds x="575" y="435" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="568" y="403" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_063omhq_di" bpmnElement="Activity_Receive">
+        <dc:Bounds x="710" y="280" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0s13zp9_di" bpmnElement="Event_ICEMessage1">
+        <dc:Bounds x="712" y="442" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="696" y="485" width="70" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0oi3p42_di" bpmnElement="Event_ICEMessage2">
+        <dc:Bounds x="712" y="552" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="696" y="595" width="70" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ju3fea_di" bpmnElement="Event_ICETimer">
+        <dc:Bounds x="712" y="662" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="707" y="705" width="47" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02bui9i_di" bpmnElement="Activity_After_Receive">
+        <dc:Bounds x="900" y="280" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1lza23k_di" bpmnElement="Activity_After_ICEMessage1">
+        <dc:Bounds x="900" y="420" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1f1lgah_di" bpmnElement="Activity_After_ICEMessage2">
+        <dc:Bounds x="900" y="530" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1n0ie5j_di" bpmnElement="Activity_After_ICETimer">
+        <dc:Bounds x="900" y="640" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1848vm5_di" bpmnElement="Event_ICETimerEnd">
+        <dc:Bounds x="1152" y="662" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1137" y="705" width="66" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hglcll_di" bpmnElement="Event_ICEMessage2End">
+        <dc:Bounds x="1152" y="552" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1126" y="595" width="89" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1be6xv8_di" bpmnElement="Event_ICEMessage1End">
+        <dc:Bounds x="1152" y="442" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1126" y="485" width="89" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0a3m14i_di" bpmnElement="Event_ReceiveEnd">
+        <dc:Bounds x="1152" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1140" y="345" width="60" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_03sw70g_di" bpmnElement="Flow_03sw70g">
+        <di:waypoint x="368" y="460" />
+        <di:waypoint x="420" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ey34y6_di" bpmnElement="Flow_1ey34y6">
+        <di:waypoint x="520" y="460" />
+        <di:waypoint x="575" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07vgiw0_di" bpmnElement="Flow_07vgiw0">
+        <di:waypoint x="600" y="435" />
+        <di:waypoint x="600" y="320" />
+        <di:waypoint x="710" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13515ga_di" bpmnElement="Flow_13515ga">
+        <di:waypoint x="625" y="460" />
+        <di:waypoint x="712" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1siv5zn_di" bpmnElement="Flow_1siv5zn">
+        <di:waypoint x="600" y="485" />
+        <di:waypoint x="600" y="570" />
+        <di:waypoint x="712" y="570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_009p1i1_di" bpmnElement="Flow_009p1i1">
+        <di:waypoint x="600" y="485" />
+        <di:waypoint x="600" y="680" />
+        <di:waypoint x="712" y="680" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0z7lv2k_di" bpmnElement="Flow_0z7lv2k">
+        <di:waypoint x="810" y="320" />
+        <di:waypoint x="900" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nrp589_di" bpmnElement="Flow_0nrp589">
+        <di:waypoint x="748" y="460" />
+        <di:waypoint x="900" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0aufudp_di" bpmnElement="Flow_0aufudp">
+        <di:waypoint x="748" y="570" />
+        <di:waypoint x="900" y="570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yh856b_di" bpmnElement="Flow_1yh856b">
+        <di:waypoint x="748" y="680" />
+        <di:waypoint x="900" y="680" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fp8uvo_di" bpmnElement="Flow_0fp8uvo">
+        <di:waypoint x="1000" y="680" />
+        <di:waypoint x="1152" y="680" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1j37tji_di" bpmnElement="Flow_1j37tji">
+        <di:waypoint x="1000" y="570" />
+        <di:waypoint x="1152" y="570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bexo21_di" bpmnElement="Flow_0bexo21">
+        <di:waypoint x="1000" y="460" />
+        <di:waypoint x="1152" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lbe0co_di" bpmnElement="Flow_0lbe0co">
+        <di:waypoint x="1000" y="320" />
+        <di:waypoint x="1152" y="320" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/models/A21g - Basic Messageflow - Timer BE on ReceiveTask_0.bpmn
+++ b/test/models/A21g - Basic Messageflow - Timer BE on ReceiveTask_0.bpmn
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:apex="https://flowsforapex.org" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1wzb475" targetNamespace="http://bpmn.io/schema/b" exporter="Flows for APEX" exporterVersion="23.1.0">
+  <bpmn:process id="Process_A21g" name="A21g Timers on ReceiveTask" isExecutable="true" apex:manualInput="false">
+    <bpmn:startEvent id="Event_Start" name="Start">
+      <bpmn:outgoing>Flow_0bhuist</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_BeforeTest1" name="Before Test1">
+      <bpmn:incoming>Flow_0bhuist</bpmn:incoming>
+      <bpmn:outgoing>Flow_1llp3ej</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0bhuist" sourceRef="Event_Start" targetRef="Activity_BeforeTest1" />
+    <bpmn:sequenceFlow id="Flow_1llp3ej" sourceRef="Activity_BeforeTest1" targetRef="Activity_Receive1" />
+    <bpmn:sequenceFlow id="Flow_1ixcfta" sourceRef="Activity_Receive1" targetRef="Activity_BeforeTest2" />
+    <bpmn:task id="Activity_AfterTest" name="After Test">
+      <bpmn:incoming>Flow_0vrfdql</bpmn:incoming>
+      <bpmn:outgoing>Flow_0stqmgg</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0vrfdql" sourceRef="Activity_Receive2" targetRef="Activity_AfterTest" />
+    <bpmn:endEvent id="Event_End" name="End">
+      <bpmn:incoming>Flow_0stqmgg</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0stqmgg" sourceRef="Activity_AfterTest" targetRef="Event_End" />
+    <bpmn:task id="Activity_AfterBE1" name="After BE1">
+      <bpmn:incoming>Flow_1d1s8fw</bpmn:incoming>
+      <bpmn:outgoing>Flow_0czwt5u</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1d1s8fw" sourceRef="Event_BE1NITimer" targetRef="Activity_AfterBE1" />
+    <bpmn:endEvent id="Event_BE1End" name="BE1End">
+      <bpmn:incoming>Flow_0czwt5u</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0czwt5u" sourceRef="Activity_AfterBE1" targetRef="Event_BE1End" />
+    <bpmn:task id="Activity_AfterBE2" name="After BE2">
+      <bpmn:incoming>Flow_0pf35fx</bpmn:incoming>
+      <bpmn:outgoing>Flow_09zgax1</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0pf35fx" sourceRef="Event_BE2IntTimer" targetRef="Activity_AfterBE2" />
+    <bpmn:endEvent id="Event_BE2End" name="BE2End">
+      <bpmn:incoming>Flow_09zgax1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_09zgax1" sourceRef="Activity_AfterBE2" targetRef="Event_BE2End" />
+    <bpmn:receiveTask id="Activity_Receive1" name="Receive1" apex:type="basicApexMessage">
+      <bpmn:extensionElements>
+        <apex:messageName>
+          <apex:expressionType>plsqlRawFunctionBody</apex:expressionType>
+          <apex:expression>return 'MyMessage';</apex:expression>
+        </apex:messageName>
+        <apex:correlationKey>
+          <apex:expressionType>plsqlRawFunctionBody</apex:expressionType>
+          <apex:expression>return 'MyKey';</apex:expression>
+        </apex:correlationKey>
+        <apex:correlationValue>
+          <apex:expressionType>plsqlRawFunctionBody</apex:expressionType>
+          <apex:expression>return 'Receive1';</apex:expression>
+        </apex:correlationValue>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1llp3ej</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ixcfta</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:boundaryEvent id="Event_BE1NITimer" name="BE1NITimer" cancelActivity="false" attachedToRef="Activity_Receive1">
+      <bpmn:outgoing>Flow_1d1s8fw</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1ni5q1m" apex:timerType="oracleDuration">
+        <bpmn:extensionElements>
+          <apex:oracleDuration>
+            <apex:intervalDS>000 00:00:05</apex:intervalDS>
+          </apex:oracleDuration>
+        </bpmn:extensionElements>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:receiveTask id="Activity_Receive2" name="Receive2" apex:type="basicApexMessage">
+      <bpmn:extensionElements>
+        <apex:messageName>
+          <apex:expressionType>plsqlRawExpression</apex:expressionType>
+          <apex:expression>'MyMessage'</apex:expression>
+        </apex:messageName>
+        <apex:correlationKey>
+          <apex:expressionType>plsqlRawExpression</apex:expressionType>
+          <apex:expression>'MyKey'</apex:expression>
+        </apex:correlationKey>
+        <apex:correlationValue>
+          <apex:expressionType>plsqlRawExpression</apex:expressionType>
+          <apex:expression>'Receive2'</apex:expression>
+        </apex:correlationValue>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_19kghop</bpmn:incoming>
+      <bpmn:outgoing>Flow_0vrfdql</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:boundaryEvent id="Event_BE2IntTimer" name="BE2IntTimer" attachedToRef="Activity_Receive2">
+      <bpmn:outgoing>Flow_0pf35fx</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0655pv1">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT5S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:task id="Activity_BeforeTest2" name="Before Test2">
+      <bpmn:incoming>Flow_1ixcfta</bpmn:incoming>
+      <bpmn:outgoing>Flow_19kghop</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_19kghop" sourceRef="Activity_BeforeTest2" targetRef="Activity_Receive2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_A21g">
+      <bpmndi:BPMNShape id="Event_088r0zs_di" bpmnElement="Event_Start">
+        <dc:Bounds x="452" y="412" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="458" y="455" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0c9sj2f_di" bpmnElement="Activity_BeforeTest1">
+        <dc:Bounds x="540" y="390" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ogbval_di" bpmnElement="Activity_AfterBE1">
+        <dc:Bounds x="830" y="510" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1onuxo9_di" bpmnElement="Activity_Receive1">
+        <dc:Bounds x="700" y="390" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0f4bob1_di" bpmnElement="Event_End">
+        <dc:Bounds x="1322" y="412" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1330" y="455" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1gfp6nz_di" bpmnElement="Activity_AfterTest">
+        <dc:Bounds x="1170" y="390" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_07ms1ux_di" bpmnElement="Activity_Receive2">
+        <dc:Bounds x="1030" y="390" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0nrp2o9_di" bpmnElement="Event_BE2End">
+        <dc:Bounds x="1322" y="292" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1320" y="335" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1v0n6j4_di" bpmnElement="Activity_AfterBE2">
+        <dc:Bounds x="1170" y="270" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lgl71w_di" bpmnElement="Event_BE1End">
+        <dc:Bounds x="1322" y="532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1320" y="575" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0w1270v_di" bpmnElement="Activity_BeforeTest2">
+        <dc:Bounds x="860" y="390" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1488c7l_di" bpmnElement="Event_BE1NITimer">
+        <dc:Bounds x="742" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="690" y="483" width="60" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1sb6w3o_di" bpmnElement="Event_BE2IntTimer">
+        <dc:Bounds x="1062" y="372" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1009" y="353" width="61" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0bhuist_di" bpmnElement="Flow_0bhuist">
+        <di:waypoint x="488" y="430" />
+        <di:waypoint x="540" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1llp3ej_di" bpmnElement="Flow_1llp3ej">
+        <di:waypoint x="640" y="430" />
+        <di:waypoint x="700" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ixcfta_di" bpmnElement="Flow_1ixcfta">
+        <di:waypoint x="800" y="430" />
+        <di:waypoint x="860" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1d1s8fw_di" bpmnElement="Flow_1d1s8fw">
+        <di:waypoint x="760" y="488" />
+        <di:waypoint x="760" y="550" />
+        <di:waypoint x="830" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0czwt5u_di" bpmnElement="Flow_0czwt5u">
+        <di:waypoint x="930" y="550" />
+        <di:waypoint x="1322" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vrfdql_di" bpmnElement="Flow_0vrfdql">
+        <di:waypoint x="1130" y="430" />
+        <di:waypoint x="1170" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0stqmgg_di" bpmnElement="Flow_0stqmgg">
+        <di:waypoint x="1270" y="430" />
+        <di:waypoint x="1322" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0pf35fx_di" bpmnElement="Flow_0pf35fx">
+        <di:waypoint x="1080" y="372" />
+        <di:waypoint x="1080" y="310" />
+        <di:waypoint x="1170" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09zgax1_di" bpmnElement="Flow_09zgax1">
+        <di:waypoint x="1270" y="310" />
+        <di:waypoint x="1322" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19kghop_di" bpmnElement="Flow_19kghop">
+        <di:waypoint x="960" y="430" />
+        <di:waypoint x="1030" y="430" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/models/import.json
+++ b/test/models/import.json
@@ -528,5 +528,51 @@
         "dgrm_status":"draft",
         "dgrm_category":"Testing",
         "file":"A20e - Diagram Startability - FuncBody_0.bpmn" 
+    },
+    {
+        "dgrm_name":"A21a - Messageflow - basics",
+        "dgrm_version":"0","dgrm_status":"draft",
+        "dgrm_category":"Testing","file":"A21a - Messageflow - basics_0.bpmn"
+    },
+    {
+        "dgrm_name":"A21b - Messageflow - basics - no payload",
+        "dgrm_version":"0",
+        "dgrm_status":"draft",
+        "dgrm_category":"Testing",
+        "file":"A21b - Messageflow - basics - no payload_0.bpmn"
+        },
+    {
+        "dgrm_name":"A21c - Messageflow - bad endpoint",
+        "dgrm_version":"0","dgrm_status":"draft",
+        "dgrm_category":"Testing",
+        "file":"A21c - Messageflow - bad endpoint_0.bpmn"
+        },
+    {
+        "dgrm_name":"A21d - Messageflow - basics - Collaboration",
+        "dgrm_version":"0",
+        "dgrm_status":"draft",
+        "dgrm_category":"Testing",
+        "file":"A21d - Messageflow - basics - Collaboration_0.bpmn"
+    },
+    {
+        "dgrm_name":"A21e - MessageFlow basics - Subscription Cancellation",
+        "dgrm_version":"0",
+        "dgrm_status":"draft",
+        "dgrm_category":"Testing",
+        "file":"A21e - MessageFlow basics - Subscription Cancellation_0.bpmn"
+    },
+    {
+        "dgrm_name":"A21f - Basic Messageflow - EBG",
+        "dgrm_version":"0",
+        "dgrm_status":"draft",
+        "dgrm_category":"Testing",
+        "file":"A21f - Basic Messageflow - EBG_0.bpmn"
+    },
+    {
+        "dgrm_name":"A21g - Basic Messageflow - Timer BE on ReceiveTask",
+        "dgrm_version":"0",
+        "dgrm_status":"draft",
+        "dgrm_category":"Testing",
+        "file":"A21g - Basic Messageflow - Timer BE on ReceiveTask_0.bpmn"
     }
 ]

--- a/test/plsql/test_021_messageFlow_basics.pkb
+++ b/test/plsql/test_021_messageFlow_basics.pkb
@@ -1864,7 +1864,7 @@ create or replace package body test_021_messageFlow_basics as
     case p_BE2_fires
     when true then
       -- want timer to fire first so wait before sending message
-      dbms_session.sleep(12);
+      dbms_session.sleep(16);
 
       -- check all subflows correct
 

--- a/test/plsql/test_021_messageFlow_basics.pkb
+++ b/test/plsql/test_021_messageFlow_basics.pkb
@@ -1,0 +1,2015 @@
+create or replace package body test_021_messageFlow_basics as
+/* 
+-- Flows for APEX - test_021_messageFlow_basics.pkb
+-- 
+-- (c) Copyright Oracle Corporation and / or its affiliates, 2023.
+--
+-- Created 17-Apr-2023   Richard Allen - Oracle
+--
+*/
+
+  -- uses models A21a
+  g_model_a21a constant varchar2(100) := 'A21a - Messageflow - basics';
+  g_model_a21b constant varchar2(100) := 'A21b - Messageflow - basics - no payload';
+  g_model_a21c constant varchar2(100) := 'A21c - Messageflow - bad endpoint';
+  g_model_a21d constant varchar2(100) := 'A21d - Messageflow - basics - Collaboration';
+  g_model_a21e constant varchar2(100) := 'A21e - MessageFlow basics - Subscription Cancellation';
+  g_model_a21f constant varchar2(100) := 'A21f - Basic Messageflow - EBG';
+  g_model_a21g constant varchar2(100) := 'A21g - Basic Messageflow - Timer BE on ReceiveTask';
+
+  g_test_prcs_name_a1 constant varchar2(100) := 'test - MessageFlow basics - a1';
+  g_test_prcs_name_a2 constant varchar2(100) := 'test - MessageFlow basics - a2';
+  g_test_prcs_name_b1 constant varchar2(100) := 'test - MessageFlow basics - b1';
+  g_test_prcs_name_b2 constant varchar2(100) := 'test - MessageFlow basics - b2';
+  g_test_prcs_name_c1 constant varchar2(100) := 'test - MessageFlow basics - c1';
+  g_test_prcs_name_c2 constant varchar2(100) := 'test - MessageFlow basics - c2';
+  g_test_prcs_name_d1 constant varchar2(100) := 'test - MessageFlow basics - d1';
+  g_test_prcs_name_d2 constant varchar2(100) := 'test - MessageFlow basics - d2';
+  g_test_prcs_name_e1 constant varchar2(100) := 'test - MessageFlow basics - e1';
+  g_test_prcs_name_e2 constant varchar2(100) := 'test - MessageFlow basics - e2';
+  g_test_prcs_name_f1 constant varchar2(100) := 'test - MessageFlow basics - f1';
+  g_test_prcs_name_f2 constant varchar2(100) := 'test - MessageFlow basics - f2';
+  g_test_prcs_name_g1 constant varchar2(100) := 'test - MessageFlow basics - g1';
+  g_test_prcs_name_g2 constant varchar2(100) := 'test - MessageFlow basics - g2';
+  g_test_prcs_name_h  constant varchar2(100) := 'test - MessageFlow basics - h';
+  g_test_prcs_name_i  constant varchar2(100) := 'test - MessageFlow basics - i';
+  g_test_prcs_name_j  constant varchar2(100) := 'test - MessageFlow basics - j';
+
+  g_prcs_id_a1       flow_processes.prcs_id%type;
+  g_prcs_id_a2       flow_processes.prcs_id%type;
+  g_prcs_id_b1       flow_processes.prcs_id%type;
+  g_prcs_id_b2       flow_processes.prcs_id%type;
+  g_prcs_id_c1       flow_processes.prcs_id%type;
+  g_prcs_id_c2       flow_processes.prcs_id%type;
+  g_prcs_id_d1       flow_processes.prcs_id%type;
+  g_prcs_id_d2       flow_processes.prcs_id%type;
+  g_prcs_id_e1       flow_processes.prcs_id%type;
+  g_prcs_id_e2       flow_processes.prcs_id%type;
+  g_prcs_id_f1       flow_processes.prcs_id%type;
+  g_prcs_id_f2       flow_processes.prcs_id%type;
+  g_prcs_id_g1       flow_processes.prcs_id%type;
+  g_prcs_id_g2       flow_processes.prcs_id%type;
+  g_prcs_id_h        flow_processes.prcs_id%type;
+  g_prcs_id_i        flow_processes.prcs_id%type;
+  g_prcs_id_ij       flow_processes.prcs_id%type;
+
+  g_dgrm_a21a_id  flow_diagrams.dgrm_id%type;
+  g_dgrm_a21b_id  flow_diagrams.dgrm_id%type;
+  g_dgrm_a21c_id  flow_diagrams.dgrm_id%type;
+  g_dgrm_a21d_id  flow_diagrams.dgrm_id%type;
+  g_dgrm_a21e_id  flow_diagrams.dgrm_id%type;
+  g_dgrm_a21f_id  flow_diagrams.dgrm_id%type;
+  g_dgrm_a21g_id  flow_diagrams.dgrm_id%type;
+
+  procedure set_up_tests
+  is 
+  begin
+  
+    -- get dgrm_ids to use for comparison
+    g_dgrm_a21a_id := test_helper.set_dgrm_id( pi_dgrm_name => g_model_a21a );
+    g_dgrm_a21b_id := test_helper.set_dgrm_id( pi_dgrm_name => g_model_a21b );
+    g_dgrm_a21c_id := test_helper.set_dgrm_id( pi_dgrm_name => g_model_a21c );
+    g_dgrm_a21d_id := test_helper.set_dgrm_id( pi_dgrm_name => g_model_a21d );
+    g_dgrm_a21e_id := test_helper.set_dgrm_id( pi_dgrm_name => g_model_a21e );
+    g_dgrm_a21f_id := test_helper.set_dgrm_id( pi_dgrm_name => g_model_a21f );
+    g_dgrm_a21g_id := test_helper.set_dgrm_id( pi_dgrm_name => g_model_a21g );
+
+    --flow_bpmn_parser_pkg.parse( pi_dgrm_id => g_dgrm_a21a_id);  -- REMOVE PARSE UNTIL 'NOT PARSING PAYLOADVARIABLE BUG" fixed
+    flow_bpmn_parser_pkg.parse( pi_dgrm_id => g_dgrm_a21b_id);  -- can parse nowbecause no payloadVariable defined
+    flow_bpmn_parser_pkg.parse( pi_dgrm_id => g_dgrm_a21c_id);
+    -- flow_bpmn_parser_pkg.parse( pi_dgrm_id => g_dgrm_a21d_id);  -- REMOVE PARSE UNTIL 'NOT PARSING PAYLOADVARIABLE BUG" fixed
+    flow_bpmn_parser_pkg.parse( pi_dgrm_id => g_dgrm_a21e_id);
+    flow_bpmn_parser_pkg.parse( pi_dgrm_id => g_dgrm_a21f_id);
+    flow_bpmn_parser_pkg.parse( pi_dgrm_id => g_dgrm_a21g_id);
+
+  end set_up_tests; 
+
+
+  function run_messageflow_model
+  ( p_prcs_name   in flow_processes.prcs_name%type
+  , p_dgrm_id     in flow_diagrams.dgrm_id%type default g_dgrm_a21a_id
+  , p_path        in varchar2
+  , p_role        in varchar2    -- 'send' or 'receive' (or 'send-manual' to skip after send tests)
+  , p_has_payload in varchar2 default 'true'
+  , p_endpoint    in varchar2 default 'local'
+  , p_rx_prcs_id  in flow_processes.prcs_id%type default null -- used for the receiving prcs_id if this is a sending prcs (to check msg sub)
+  ) return flow_processes.prcs_id%type
+  is
+    l_actual          sys_refcursor;
+    l_expected        sys_refcursor;
+    l_dgrm_id         flow_diagrams.dgrm_id%type;
+    l_prcs_name       flow_processes.prcs_name%type;
+    l_prcs_id         flow_processes.prcs_id%type;
+  begin
+    -- get dgrm_id to use for comparaison
+    l_dgrm_id     := p_dgrm_id;
+    l_prcs_name   := p_prcs_name;
+    -- create a new instance
+    l_prcs_id := flow_api_pkg.flow_create
+                  ( pi_dgrm_id   => l_dgrm_id
+                  , pi_prcs_name => l_prcs_name
+                  );
+    
+    -- start process and check running status
+    
+    flow_api_pkg.flow_start( p_process_id => l_prcs_id );
+
+    open l_expected for
+        select
+        l_dgrm_id                                   as prcs_dgrm_id,
+        l_prcs_name                                 as prcs_name,
+        flow_constants_pkg.gc_prcs_status_running   as prcs_status
+        from dual;
+    open l_actual for
+        select prcs_dgrm_id, prcs_name, prcs_status 
+          from flow_processes p
+         where p.prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_equal( l_expected );
+
+    -- check no existing process variables
+
+    open l_expected for  
+      select 'messageName' as name, 'VARCHAR2' as type, 'MyMessage' as vc2
+      from dual
+      union
+      select 'messageKey' as name, 'VARCHAR2' as type, 'keya21a' as vc2
+      from dual
+      union
+      select 'messageValue' as name, 'VARCHAR2' as type, 'a21a' as vc2
+      from dual
+      union
+      select 'messagePayload' as name, 'VARCHAR2' as type, 'originalPayload' as vc2
+      from dual
+      where p_has_payload = 'true'
+      ;
+    
+    open l_actual for
+      select prov_var_name as name, prov_var_type as type, prov_var_vc2 as vc2
+      from flow_process_variables
+      where prov_prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_equal( l_expected).unordered;    
+
+    -- set up 'path' process variable based on the type of catcher or sender required
+
+    flow_process_vars.set_var(pi_prcs_id  =>  l_prcs_id,
+                              pi_var_name  => 'path',
+                              pi_vc2_value  => p_path,
+                              pi_scope  => 0);
+
+    -- check subflow running
+
+    open l_expected for
+       select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Activity_Before' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_running sbfl_status
+       from dual;
+
+    open l_actual for
+       select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+       from flow_subflows 
+       where sbfl_prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- Step forward through gateway to sender/receiver
+
+    test_helper.step_forward(pi_prcs_id => l_prcs_id, pi_current => 'Activity_Before');    
+
+    case p_role
+    when 'receive' then
+
+      -- check if message subscription has been created
+
+      open l_expected for
+        select l_prcs_id         as prcs_id
+             , 'MyMessage'       as message_name
+             , 'keya21a'         as message_key
+             , 'a21a'            as message_value
+             , case p_has_payload 
+               when 'true' then 'returnPayload'  
+               else ''  
+               end as payload_var
+        from dual;
+      open l_actual for
+        select msub_prcs_id      as prcs_id
+             , msub_message_name as message_name
+             , msub_key_name     as message_key
+             , msub_key_value    as message_value
+             , msub_payload_var  as payload_var   
+          from flow_message_subscriptions
+         where msub_prcs_id = l_prcs_id;
+      ut.expect(l_actual).to_equal(l_expected).unordered;
+
+      -- check that the process is still on the receive object         
+
+      open l_expected for
+         select
+            l_prcs_id as sbfl_prcs_id,
+            l_dgrm_id as sbfl_dgrm_id,
+            p_path    as sbfl_current,
+            flow_constants_pkg.gc_sbfl_status_waiting_message sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    when 'send' then
+
+      -- check if message subscription has been consumed
+
+      open l_actual for
+        select msub_prcs_id      as prcs_id
+             , msub_message_name as message_name
+             , msub_key_name     as message_key
+             , msub_key_value    as message_value
+             , msub_payload_var  as payload_var   
+          from flow_message_subscriptions
+         where msub_prcs_id = p_rx_prcs_id;
+      ut.expect(l_actual).to_be_empty;
+
+      -- check that the process has moved beyond the receive object         
+
+      open l_expected for
+         select
+            l_prcs_id as sbfl_prcs_id,
+            l_dgrm_id as sbfl_dgrm_id,
+            'Activity_After'||p_path as sbfl_current,    
+            flow_constants_pkg.gc_sbfl_status_running sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_id;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      when 'send-manual' then
+        -- testing will be done in the calling routine.
+        null;
+    end case;
+
+    return l_prcs_id;
+  end run_messageflow_model;
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests A: Basic Send to Waiting Catch - With Payload - All combinations of {send, Throw} to {receive, catch}
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  -- test(A1 - Send to Receive with Payload)
+  procedure basic_receive_send_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_a1
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'Receive'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_a2
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'Send'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_equal(to_clob('originalPayload'));
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_receive_send_payload;
+
+  -- test(A2 - ITE to Receive with Payload)
+  procedure basic_receive_ITE_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_a1
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'Receive'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_a2
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'ITE'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_equal(to_clob('originalPayload'));
+
+    -- tear down processes                                       
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_receive_ITE_payload;
+
+    -- test(A3 - Send to ICE with Payload)
+  procedure basic_ICE_send_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_a1
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'ICE'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_a2
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'Send'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_equal(to_clob('originalPayload'));
+
+    -- tear down processes
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_ICE_send_payload;
+
+    -- test(A4 - ITE to ICE with Payload)
+  procedure basic_ICE_ITE_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_a1
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'ICE'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_a2
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'ITE'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_equal(to_clob('originalPayload'));
+
+    -- tear down processes                                       
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_ICE_ITE_payload;
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests B: Basic Send to Waiting Catch - Without Payloads - All combinations of {send, Throw} to {receive, catch}
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  -- test(B1 - Send to Receive with no Payload)
+  procedure basic_receive_send_no_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_b1
+                                       , p_dgrm_id      => g_dgrm_a21b_id
+                                       , p_path         => 'Receive'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_b2
+                                       , p_dgrm_id      => g_dgrm_a21b_id
+                                       , p_path         => 'Send'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_be_null;
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_receive_send_no_payload;
+
+  -- test(B2 - ITE to Receive with Payload)
+  procedure basic_receive_ITE_no_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_b1
+                                       , p_dgrm_id      => g_dgrm_a21b_id
+                                       , p_path         => 'Receive'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_b2
+                                       , p_dgrm_id      => g_dgrm_a21b_id
+                                       , p_path         => 'ITE'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_be_null;
+
+    -- tear down processes                                       
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_receive_ITE_no_payload;
+
+    -- test(B3 - Send to ICE with No Payload)
+  procedure basic_ICE_send_no_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_b1
+                                       , p_dgrm_id      => g_dgrm_a21b_id
+                                       , p_path         => 'ICE'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_b2
+                                       , p_dgrm_id      => g_dgrm_a21b_id
+                                       , p_path         => 'Send'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_be_null;
+
+    -- tear down processes
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_ICE_send_no_payload;
+
+    -- test(B4 - ITE to ICE with No Payload)
+  procedure basic_ICE_ITE_no_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_b1
+                                       , p_dgrm_id      => g_dgrm_a21b_id
+                                       , p_path         => 'ICE'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_b2
+                                       , p_dgrm_id      => g_dgrm_a21b_id
+                                       , p_path         => 'ITE'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_be_null;
+
+    -- tear down processes                                       
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_ICE_ITE_no_payload;
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests C: Throw to No Catch - All combinations of {send, Throw} to {receive, catch}
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  -- test(C1 - Send without Receive with  Payload)
+  procedure basic_send_without_receive_payload
+  is
+    l_prcs_rx         flow_processes.prcs_id%type;
+    l_prcs_tx         flow_processes.prcs_id%type;
+    l_actual_clob     clob;
+    l_actual          sys_refcursor;
+    l_expected        sys_refcursor;
+  begin
+
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_c1
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'Send'
+                                       , p_role         => 'send-manual'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+      -- check that the send task subflow is now in error         
+
+      open l_expected for
+         select
+            l_prcs_tx as sbfl_prcs_id,
+            'Send'    as sbfl_current,    
+            flow_constants_pkg.gc_sbfl_status_error sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id,  sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      -- check that the send process is now in error         
+
+      open l_expected for
+         select
+            l_prcs_tx as prcs_id,
+            flow_constants_pkg.gc_prcs_status_error prcs_status
+         from dual;
+
+      open l_actual for
+         select prcs_id, prcs_status 
+         from flow_processes 
+         where prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_send_without_receive_payload;
+
+  -- test(C2 - Throw without Receive with  Payload)
+  procedure basic_ITE_without_receive_payload
+  is
+    l_prcs_rx         flow_processes.prcs_id%type;
+    l_prcs_tx         flow_processes.prcs_id%type;
+    l_actual_clob     clob;
+    l_actual          sys_refcursor;
+    l_expected        sys_refcursor;
+  begin
+
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_c1
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'ITE'
+                                       , p_role         => 'send-manual'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+      -- check that the send task subflow is now in error         
+
+      open l_expected for
+         select
+            l_prcs_tx as sbfl_prcs_id,
+            'ITE'    as sbfl_current,    
+            flow_constants_pkg.gc_sbfl_status_error sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id,  sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      -- check that the send process is now in error         
+
+      open l_expected for
+         select
+            l_prcs_tx as prcs_id,
+            flow_constants_pkg.gc_prcs_status_error prcs_status
+         from dual;
+
+      open l_actual for
+         select prcs_id, prcs_status 
+         from flow_processes 
+         where prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_ITE_without_receive_payload;
+
+
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests D: Restarability of Send task after non-correlation error fixed
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  -- test(D1 - Error Restart after Send without Receive with  Payload)
+  procedure basic_send_without_receive_payload_restart
+  is
+    l_prcs_rx         flow_processes.prcs_id%type;
+    l_prcs_tx         flow_processes.prcs_id%type;
+    l_actual_clob     clob;
+    l_actual          sys_refcursor;
+    l_expected        sys_refcursor;
+    l_sending_path    varchar2(20) := 'Send';
+  begin
+
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_d1
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => l_sending_path
+                                       , p_role         => 'send-manual'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+      -- check that the send task subflow is now in error         
+
+      open l_expected for
+         select
+            l_prcs_tx         as sbfl_prcs_id,
+            l_sending_path    as sbfl_current,    
+            flow_constants_pkg.gc_sbfl_status_error sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id,  sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      -- check that the send process is now in error         
+
+      open l_expected for
+         select
+            l_prcs_tx as prcs_id,
+            flow_constants_pkg.gc_prcs_status_error prcs_status
+         from dual;
+
+      open l_actual for
+         select prcs_id, prcs_status 
+         from flow_processes 
+         where prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      -- now start the receive task to create a subscription
+
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_d2
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'Receive'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- then restart the Sending process and it should proceed...
+
+    test_helper.restart_forward(pi_prcs_id  => l_prcs_tx,
+                                pi_current  => l_sending_path);
+
+      -- check that the send task subflow is now on After step and running       
+
+      open l_expected for
+         select
+            l_prcs_tx                                 as sbfl_prcs_id,
+            'Activity_AfterSend'                      as sbfl_current,    
+            flow_constants_pkg.gc_sbfl_status_running as sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id,  sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;                                
+
+
+      -- check that the receiver task subflow is now on After step and running       
+
+      open l_expected for
+         select
+            l_prcs_rx                                 as sbfl_prcs_id,
+            'Activity_AfterReceive'                   as sbfl_current,    
+            flow_constants_pkg.gc_sbfl_status_running as sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id,  sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_rx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;                                
+
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_send_without_receive_payload_restart;
+
+
+
+  -- test(D2 - Error Restart after Send without Receive with  Payload)
+  procedure basic_ITE_without_receive_payload_restart
+  is
+    l_prcs_rx         flow_processes.prcs_id%type;
+    l_prcs_tx         flow_processes.prcs_id%type;
+    l_actual_clob     clob;
+    l_actual          sys_refcursor;
+    l_expected        sys_refcursor;
+    l_sending_path    varchar2(20) := 'ITE';
+  begin
+
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_d1
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => l_sending_path
+                                       , p_role         => 'send-manual'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+      -- check that the send task subflow is now in error         
+
+      open l_expected for
+         select
+            l_prcs_tx         as sbfl_prcs_id,
+            l_sending_path    as sbfl_current,    
+            flow_constants_pkg.gc_sbfl_status_error sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id,  sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      -- check that the send process is now in error         
+
+      open l_expected for
+         select
+            l_prcs_tx as prcs_id,
+            flow_constants_pkg.gc_prcs_status_error prcs_status
+         from dual;
+
+      open l_actual for
+         select prcs_id, prcs_status 
+         from flow_processes 
+         where prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      -- now start the receive task to create a subscription
+
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_d2
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'Receive'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- then restart the Sending process and it should proceed...
+
+    test_helper.restart_forward(pi_prcs_id  => l_prcs_tx,
+                                pi_current  => l_sending_path);
+
+      -- check that the send task subflow is now on After step and running       
+
+      open l_expected for
+         select
+            l_prcs_tx                                 as sbfl_prcs_id,
+            'Activity_AfterITE'                      as sbfl_current,    
+            flow_constants_pkg.gc_sbfl_status_running as sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id,  sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;                                
+
+
+      -- check that the receiver task subflow is now on After step and running       
+
+      open l_expected for
+         select
+            l_prcs_rx                                 as sbfl_prcs_id,
+            'Activity_AfterReceive'                   as sbfl_current,    
+            flow_constants_pkg.gc_sbfl_status_running as sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id,  sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_rx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;                                
+
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_ITE_without_receive_payload_restart;
+
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests E: Bad Endpoint
+ -- 
+ ---------------------------------------------------------------------------------------------------------------  
+
+ -- test(E1 - Send with bad endpoint)
+  procedure bad_endpoint_send
+  is
+    l_prcs_rx         flow_processes.prcs_id%type;
+    l_prcs_tx         flow_processes.prcs_id%type;
+    l_actual_clob     clob;
+    l_actual          sys_refcursor;
+    l_expected        sys_refcursor;
+  begin
+
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_e1
+                                       , p_dgrm_id      => g_dgrm_a21c_id
+                                       , p_path         => 'Send'
+                                       , p_role         => 'send-manual'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+      -- check that the send task subflow is now in error         
+
+      open l_expected for
+         select
+            l_prcs_tx as sbfl_prcs_id,
+            'Send'    as sbfl_current,    
+            flow_constants_pkg.gc_sbfl_status_error sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id,  sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      -- check that the send process is now in error         
+
+      open l_expected for
+         select
+            l_prcs_tx as prcs_id,
+            flow_constants_pkg.gc_prcs_status_error prcs_status
+         from dual;
+
+      open l_actual for
+         select prcs_id, prcs_status 
+         from flow_processes 
+         where prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end bad_endpoint_send;
+
+
+ -- test(E2 - Send with bad endpoint)
+  procedure bad_endpoint_ITE
+  is
+    l_prcs_rx         flow_processes.prcs_id%type;
+    l_prcs_tx         flow_processes.prcs_id%type;
+    l_actual_clob     clob;
+    l_actual          sys_refcursor;
+    l_expected        sys_refcursor;
+  begin
+
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_e1
+                                       , p_dgrm_id      => g_dgrm_a21c_id
+                                       , p_path         => 'ITE'
+                                       , p_role         => 'send-manual'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+      -- check that the send task subflow is now in error         
+
+      open l_expected for
+         select
+            l_prcs_tx as sbfl_prcs_id,
+            'ITE'    as sbfl_current,    
+            flow_constants_pkg.gc_sbfl_status_error sbfl_status
+         from dual;
+
+      open l_actual for
+         select sbfl_prcs_id,  sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      -- check that the send process is now in error         
+
+      open l_expected for
+         select
+            l_prcs_tx as prcs_id,
+            flow_constants_pkg.gc_prcs_status_error prcs_status
+         from dual;
+
+      open l_actual for
+         select prcs_id, prcs_status 
+         from flow_processes 
+         where prcs_id = l_prcs_tx;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end bad_endpoint_ITE;
+
+ 
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests F: Mismatched Payloads (send unexpected payload / missing expected payload)
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+ 
+  -- test(F1 - Send to Receive with Unexpected Payload)
+  procedure basic_receive_send_unexpected_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_f1
+                                       , p_dgrm_id      => g_dgrm_a21b_id
+                                       , p_path         => 'Receive'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_f2
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'Send'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_be_null;
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_receive_send_unexpected_payload;
+
+  -- test(F2 - ITE to ICE with Unexpected Payload)
+  procedure basic_ICE_ITE_unexpected_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_f1
+                                       , p_dgrm_id      => g_dgrm_a21b_id
+                                       , p_path         => 'ICE'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_f2
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'ITE'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_be_null;
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_ICE_ITE_unexpected_payload;
+
+  -- test(F3 - Send to Receive with missing Payload)
+  procedure basic_receive_send_missing_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_f1
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'Receive'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_f2
+                                       , p_dgrm_id      => g_dgrm_a21b_id
+                                       , p_path         => 'Send'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_be_null;
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_receive_send_missing_payload;
+
+  -- test(F3 - ITE to ICE with missing Payload)
+  procedure basic_ICE_ITE_missing_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_f1
+                                       , p_dgrm_id      => g_dgrm_a21a_id
+                                       , p_path         => 'ICE'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_f2
+                                       , p_dgrm_id      => g_dgrm_a21b_id
+                                       , p_path         => 'ITE'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'false'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_be_null;
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end basic_ICE_ITE_missing_payload;
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests G: Basic Send to Waiting Catch - With Payload - All combinations of {send, Throw} to {receive, catch}
+ --   (reruns set A with a diagram including Lanes and an empty pool)
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+   -- test(G1 - Send to Receive with Payload)
+  procedure colab_receive_send_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_g1
+                                       , p_dgrm_id      => g_dgrm_a21d_id
+                                       , p_path         => 'Receive'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_g2
+                                       , p_dgrm_id      => g_dgrm_a21d_id
+                                       , p_path         => 'Send'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_equal(to_clob('originalPayload'));
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end colab_receive_send_payload;
+
+  -- test(G2 - ITE to Receive with Payload)
+  procedure colab_receive_ITE_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_g1
+                                       , p_dgrm_id      => g_dgrm_a21d_id
+                                       , p_path         => 'Receive'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_g2
+                                       , p_dgrm_id      => g_dgrm_a21d_id
+                                       , p_path         => 'ITE'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_equal(to_clob('originalPayload'));
+
+    -- tear down processes                                       
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end colab_receive_ITE_payload;
+
+    -- test(G3 - Send to ICE with Payload)
+  procedure colab_ICE_send_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_g1
+                                       , p_dgrm_id      => g_dgrm_a21d_id
+                                       , p_path         => 'ICE'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_g2
+                                       , p_dgrm_id      => g_dgrm_a21d_id
+                                       , p_path         => 'Send'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_equal(to_clob('originalPayload'));
+
+    -- tear down processes
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end colab_ICE_send_payload;
+
+    -- test(G4 - ITE to ICE with Payload)
+  procedure colab_ICE_ITE_payload
+  is
+    l_prcs_rx     flow_processes.prcs_id%type;
+    l_prcs_tx     flow_processes.prcs_id%type;
+    l_actual_clob clob;
+  begin
+    l_prcs_rx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_g1
+                                       , p_dgrm_id      => g_dgrm_a21d_id
+                                       , p_path         => 'ICE'
+                                       , p_role         => 'receive'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+    l_prcs_tx := run_messageflow_model ( p_prcs_name    => g_test_prcs_name_g2
+                                       , p_dgrm_id      => g_dgrm_a21d_id
+                                       , p_path         => 'ITE'
+                                       , p_role         => 'send'
+                                       , p_has_payload  => 'true'
+                                       , p_endpoint     => 'local'
+                                       );
+
+    -- check the receiving object received the payload
+
+   
+    l_actual_clob := flow_process_vars.get_var_clob ( pi_prcs_id  => l_prcs_rx
+                                                    , pi_var_name  => 'returnPayload');                                                   
+    ut.expect(l_actual_clob).to_equal(to_clob('originalPayload'));
+
+    -- tear down processes                                       
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+  end colab_ICE_ITE_payload;
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests H: subscription Cancellation (check subscription gets cancelled when areceive Task gets cancelled)
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  -- test(H - Subscription Cancellation)
+  procedure subscription_cancellation
+  is
+    l_actual          sys_refcursor;
+    l_expected        sys_refcursor;
+    l_dgrm_id         flow_diagrams.dgrm_id%type;
+    l_prcs_name       flow_processes.prcs_name%type;
+    l_prcs_id         flow_processes.prcs_id%type;
+  begin
+    -- get dgrm_id to use for comparaison
+    l_dgrm_id     := g_dgrm_a21e_id;
+    l_prcs_name   := g_test_prcs_name_h;
+    -- create a new instance
+    l_prcs_id := flow_api_pkg.flow_create
+                  ( pi_dgrm_id   => l_dgrm_id
+                  , pi_prcs_name => l_prcs_name
+                  );
+    
+    -- start process and check running status
+    
+    flow_api_pkg.flow_start( p_process_id => l_prcs_id );
+
+    open l_expected for
+        select
+        l_dgrm_id                                   as prcs_dgrm_id,
+        l_prcs_name                                 as prcs_name,
+        flow_constants_pkg.gc_prcs_status_running   as prcs_status
+        from dual;
+    open l_actual for
+        select prcs_dgrm_id, prcs_name, prcs_status 
+          from flow_processes p
+         where p.prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_equal( l_expected );
+
+    -- check all parallel subflows running
+
+    open l_expected for       
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Activity_BeforeTest' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_running sbfl_status
+       from dual;
+
+    open l_actual for
+       select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+       from flow_subflows 
+       where sbfl_prcs_id = l_prcs_id
+       and sbfl_status not like 'split';
+    ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- step forward into test
+
+    test_helper.step_forward(pi_prcs_id => l_prcs_id, pi_current => 'Activity_BeforeTest');    
+
+    -- check subflows
+
+    open l_expected for       
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Activity_Receive' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_waiting_message sbfl_status
+       from dual
+       union
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Activity_BeforeErrorEnd' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_running sbfl_status
+       from dual;
+
+    open l_actual for
+       select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+       from flow_subflows 
+       where sbfl_prcs_id = l_prcs_id
+       and sbfl_status not in ('split', 'in subprocess') ;
+    ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- check if message subscription has been created
+
+    open l_expected for
+      select l_prcs_id         as prcs_id
+           , 'MyMessage'       as message_name
+           , 'myKey'           as message_key
+           , 'myValue'         as message_value
+           , ''                as payload_var
+      from dual;
+    open l_actual for
+      select msub_prcs_id      as prcs_id
+           , msub_message_name as message_name
+           , msub_key_name     as message_key
+           , msub_key_value    as message_value
+           , msub_payload_var  as payload_var   
+        from flow_message_subscriptions
+       where msub_prcs_id = l_prcs_id;
+    ut.expect(l_actual).to_equal(l_expected).unordered;
+
+    -- step forward on other subflow to cause subprocess to error-end
+
+    test_helper.step_forward(pi_prcs_id => l_prcs_id, pi_current => 'Activity_BeforeErrorEnd');    
+
+    -- now check that the subprocess activities have gone and then that the message subscription was also removed
+
+    open l_expected for       
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Activity_AfterErrorBE' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_running sbfl_status
+       from dual;
+
+    open l_actual for
+       select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+       from flow_subflows 
+       where sbfl_prcs_id = l_prcs_id
+       and sbfl_status not in ('split', 'in subprocess');
+    ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- check the subscription
+
+        open l_actual for
+      select msub_prcs_id      as prcs_id
+           , msub_message_name as message_name
+           , msub_key_name     as message_key
+           , msub_key_value    as message_value
+           , msub_payload_var  as payload_var   
+        from flow_message_subscriptions
+       where msub_prcs_id = l_prcs_id;
+    ut.expect(l_actual).to_be_empty;
+
+    -- step forward on oher subflow to end
+
+    test_helper.step_forward(pi_prcs_id => l_prcs_id, pi_current => 'Activity_AfterErrorBE');   
+
+    -- check process completed successfully
+
+    open l_expected for
+        select
+        l_dgrm_id                                     as prcs_dgrm_id,
+        l_prcs_name                                   as prcs_name,
+        flow_constants_pkg.gc_prcs_status_completed   as prcs_status
+        from dual;
+    open l_actual for
+        select prcs_dgrm_id, prcs_name, prcs_status 
+          from flow_processes p
+         where p.prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_equal( l_expected );    
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_id,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+
+  end subscription_cancellation;
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests I: MessageFlow ReceiveTask and ICE Following an Event Based Gateway
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  procedure after_ebg_tester
+  ( p_winning_path   flow_objects.objt_bpmn_id%type
+  , p_do_timeout     boolean
+  )
+  is
+    l_actual          sys_refcursor;
+    l_expected        sys_refcursor;
+    l_dgrm_id         flow_diagrams.dgrm_id%type;
+    l_prcs_name       flow_processes.prcs_name%type;
+    l_prcs_id         flow_processes.prcs_id%type;
+  begin
+    -- get dgrm_id to use for comparaison
+    l_dgrm_id     := g_dgrm_a21f_id;
+    l_prcs_name   := g_test_prcs_name_i;
+    -- create a new instance
+    l_prcs_id := flow_api_pkg.flow_create
+                  ( pi_dgrm_id   => l_dgrm_id
+                  , pi_prcs_name => l_prcs_name
+                  );
+    
+    -- start process and check running status
+    
+    flow_api_pkg.flow_start( p_process_id => l_prcs_id );
+
+    open l_expected for
+        select
+        l_dgrm_id                                   as prcs_dgrm_id,
+        l_prcs_name                                 as prcs_name,
+        flow_constants_pkg.gc_prcs_status_running   as prcs_status
+        from dual;
+    open l_actual for
+        select prcs_dgrm_id, prcs_name, prcs_status 
+          from flow_processes p
+         where p.prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_equal( l_expected );
+
+    -- check main subflows running
+
+    open l_expected for       
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Activity_BeforeGateway' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_running sbfl_status
+       from dual;
+
+    open l_actual for
+       select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+       from flow_subflows 
+       where sbfl_prcs_id = l_prcs_id
+       and sbfl_status not like 'split';
+    ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- step forward into test
+
+    test_helper.step_forward(pi_prcs_id => l_prcs_id, pi_current => 'Activity_BeforeGateway');    
+
+    -- check all paths running after EBG
+
+    open l_expected for       
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Activity_Receive' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_waiting_message sbfl_status
+       from dual
+       union
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Event_ICEMessage1' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_waiting_message sbfl_status
+       from dual
+       union
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Event_ICEMessage2' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_waiting_message sbfl_status
+       from dual
+       union
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Event_ICETimer' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_waiting_timer sbfl_status
+       from dual;
+
+    open l_actual for
+       select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+       from flow_subflows 
+       where sbfl_prcs_id = l_prcs_id
+       and sbfl_status not in ('split', 'in subprocess') ;
+    ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- check all subscriptions created
+
+    open l_expected for
+      select l_prcs_id         as prcs_id
+           , 'MyMessage'       as message_name
+           , 'Processor'           as message_key
+           , 'Receive'         as message_value
+           , ''                as payload_var
+      from dual
+      union
+      select l_prcs_id         as prcs_id
+           , 'MyMessage'       as message_name
+           , 'Processor'           as message_key
+           , 'ICEMessage1'         as message_value
+           , ''                as payload_var
+      from dual
+      union
+      select l_prcs_id         as prcs_id
+           , 'MyMessage'       as message_name
+           , 'Processor'           as message_key
+           , 'ICEMessage2'         as message_value
+           , ''                as payload_var
+      from dual;      
+    open l_actual for
+      select msub_prcs_id      as prcs_id
+           , msub_message_name as message_name
+           , msub_key_name     as message_key
+           , msub_key_value    as message_value
+           , msub_payload_var  as payload_var   
+        from flow_message_subscriptions
+       where msub_prcs_id = l_prcs_id;
+    ut.expect(l_actual).to_equal(l_expected).unordered;
+
+    -- send chosen message
+
+    if p_do_timeout then
+      -- let the timer win
+      dbms_session.sleep(15);
+    else
+      flow_api_pkg.receive_message ( p_message_name => 'MyMessage' 
+                                   , p_key_name => 'Processor' 
+                                   , p_key_value => p_winning_path
+                                   );
+    end if;
+
+    -- now check whether one 1 subflow  running
+
+    open l_expected for   
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Activity_After_'||p_winning_path as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_running sbfl_status
+       from dual;
+
+    open l_actual for
+       select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+       from flow_subflows 
+       where sbfl_prcs_id = l_prcs_id
+       and sbfl_status not in ('split', 'in subprocess') ;
+    ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- check no message subscriptions outstanding
+
+    open l_actual for
+      select msub_prcs_id      as prcs_id
+           , msub_message_name as message_name
+           , msub_key_name     as message_key
+           , msub_key_value    as message_value
+           , msub_payload_var  as payload_var   
+        from flow_message_subscriptions
+       where msub_prcs_id = l_prcs_id;
+    ut.expect(l_actual).to_be_empty;
+
+    -- step forward on other subflow to end
+
+    test_helper.step_forward(pi_prcs_id => l_prcs_id, pi_current => 'Activity_After_'||p_winning_path);   
+
+    -- check process completed successfully
+
+    open l_expected for
+        select
+        l_dgrm_id                                     as prcs_dgrm_id,
+        l_prcs_name                                   as prcs_name,
+        flow_constants_pkg.gc_prcs_status_completed   as prcs_status
+        from dual;
+    open l_actual for
+        select prcs_dgrm_id, prcs_name, prcs_status 
+          from flow_processes p
+         where p.prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_equal( l_expected );    
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_id,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+
+  end after_ebg_tester;
+
+
+  -- test(I1 - Messageflow after EBG - ReceiveTask wins)
+  procedure afterEBG_receiveTask
+  is
+  begin
+    after_ebg_tester ( p_winning_path => 'Receive', p_do_timeout => false);
+  end afterEBG_receiveTask;
+
+  -- test(I2 - Messageflow after EBG - MessageICE1 wins)
+  procedure afterEBG_messageICE1
+  is
+  begin
+    after_ebg_tester ( p_winning_path => 'ICEMessage1', p_do_timeout => false);
+  end afterEBG_messageICE1;
+
+  -- test(I3 - Messageflow after EBG - MessageICE2 wins)
+  procedure afterEBG_messageICE2
+  is
+  begin
+    after_ebg_tester ( p_winning_path => 'ICEMessage2', p_do_timeout => false);
+  end afterEBG_messageICE2;
+
+  -- test(I4 - Messageflow after EBG - Timer wins)
+  procedure afterEBGtimer
+  is
+  begin
+    after_ebg_tester ( p_winning_path => 'ICETimer', p_do_timeout => true);
+  end afterEBGtimer;
+
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests J: Timer Boundary Events on ReceiveTask
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  procedure receivetask_timer_be_runner
+  ( p_BE1_fires  boolean
+  , p_BE2_fires  boolean
+  )
+  is
+    l_actual          sys_refcursor;
+    l_expected        sys_refcursor;
+    l_dgrm_id         flow_diagrams.dgrm_id%type;
+    l_prcs_name       flow_processes.prcs_name%type;
+    l_prcs_id         flow_processes.prcs_id%type;
+  begin
+    -- get dgrm_id to use for comparaison
+    l_dgrm_id     := g_dgrm_a21g_id;
+    l_prcs_name   := g_test_prcs_name_j;
+    -- create a new instance
+    l_prcs_id := flow_api_pkg.flow_create
+                  ( pi_dgrm_id   => l_dgrm_id
+                  , pi_prcs_name => l_prcs_name
+                  );
+    
+    -- start process and check running status
+    
+    flow_api_pkg.flow_start( p_process_id => l_prcs_id );
+
+    open l_expected for
+        select
+        l_dgrm_id                                   as prcs_dgrm_id,
+        l_prcs_name                                 as prcs_name,
+        flow_constants_pkg.gc_prcs_status_running   as prcs_status
+        from dual;
+    open l_actual for
+        select prcs_dgrm_id, prcs_name, prcs_status 
+          from flow_processes p
+         where p.prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_equal( l_expected );
+
+    -- check main subflow running
+
+    open l_expected for       
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Activity_BeforeTest1' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_running sbfl_status
+       from dual;
+
+    open l_actual for
+       select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+       from flow_subflows 
+       where sbfl_prcs_id = l_prcs_id
+       and sbfl_status not like 'split';
+    ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+
+    -- step forward into test
+
+    test_helper.step_forward(pi_prcs_id => l_prcs_id, pi_current => 'Activity_BeforeTest1');   
+
+    -- check expected subflows
+
+    open l_expected for   
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Activity_Receive1' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_waiting_message sbfl_status
+       from dual
+       union
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Event_BE1NITimer' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_waiting_timer sbfl_status
+       from dual;
+
+    open l_actual for
+       select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+       from flow_subflows 
+       where sbfl_prcs_id = l_prcs_id
+       and sbfl_status not in ('split', 'in subprocess') ;
+    ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- test subscription created
+
+    open l_expected for 
+      select l_prcs_id         as prcs_id
+           , 'MyMessage'       as message_name
+           , 'MyKey'       as message_key
+           , 'Receive1'        as message_value
+           , ''                as payload_var
+      from dual;      
+    open l_actual for
+      select msub_prcs_id      as prcs_id
+           , msub_message_name as message_name
+           , msub_key_name     as message_key
+           , msub_key_value    as message_value
+           , msub_payload_var  as payload_var   
+        from flow_message_subscriptions
+       where msub_prcs_id = l_prcs_id;
+    ut.expect(l_actual).to_equal(l_expected).unordered;
+
+    case p_BE1_fires
+    when true then
+      -- want timer to fire first so wait before sending message
+      dbms_session.sleep(16);
+
+      flow_api_pkg.receive_message ( p_message_name   => 'MyMessage'
+                                   , p_key_name       => 'MyKey'
+                                   , p_key_value      => 'Receive1'
+                                   );
+
+      -- check all subflows correct
+
+      open l_expected for
+         select
+         l_prcs_id as sbfl_prcs_id,
+         l_dgrm_id as sbfl_dgrm_id,
+         'Activity_BeforeTest2' as sbfl_current,
+         flow_constants_pkg.gc_sbfl_status_running sbfl_status
+      from dual
+      union
+         select
+         l_prcs_id as sbfl_prcs_id,
+         l_dgrm_id as sbfl_dgrm_id,
+         'Activity_AfterBE1' as sbfl_current,
+         flow_constants_pkg.gc_sbfl_status_running sbfl_status
+      from dual;
+
+      open l_actual for
+         select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_id
+         and sbfl_status not in ('split', 'in subprocess') ;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      -- step forward on BE path to clear subflow
+
+      test_helper.step_forward(pi_prcs_id => l_prcs_id, pi_current => 'Activity_AfterBE1');         
+
+    when false then
+
+      flow_api_pkg.receive_message ( p_message_name   => 'MyMessage'
+                                   , p_key_name       => 'MyKey'
+                                   , p_key_value      => 'Receive1'
+                                   );
+
+    end case;
+
+    -- check all subflows correct
+    open l_expected for
+       select
+       l_prcs_id as sbfl_prcs_id,
+       l_dgrm_id as sbfl_dgrm_id,
+       'Activity_BeforeTest2' as sbfl_current,
+       flow_constants_pkg.gc_sbfl_status_running sbfl_status
+    from dual;
+    open l_actual for
+       select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+       from flow_subflows 
+       where sbfl_prcs_id = l_prcs_id
+       and sbfl_status not in ('split', 'in subprocess') ;
+    ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- ready for test 2
+
+    -- step forward into Receive2 (with its interupting timer)
+
+    test_helper.step_forward(pi_prcs_id => l_prcs_id, pi_current => 'Activity_BeforeTest2');   
+
+    -- check expected subflows
+
+    open l_expected for   
+          select
+          l_prcs_id as sbfl_prcs_id,
+          l_dgrm_id as sbfl_dgrm_id,
+          'Activity_Receive2' as sbfl_current,
+          flow_constants_pkg.gc_sbfl_status_waiting_message sbfl_status
+       from dual;
+
+    open l_actual for
+       select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+       from flow_subflows 
+       where sbfl_prcs_id = l_prcs_id
+       and sbfl_status not in ('split', 'in subprocess') ;
+    ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+    -- test subscription created
+
+
+    open l_expected for 
+          select l_prcs_id     as prcs_id
+           , 'MyMessage'       as message_name
+           , 'MyKey'       as message_key
+           , 'Receive2'        as message_value
+           , ''                as payload_var
+      from dual;      
+    open l_actual for
+      select msub_prcs_id      as prcs_id
+           , msub_message_name as message_name
+           , msub_key_name     as message_key
+           , msub_key_value    as message_value
+           , msub_payload_var  as payload_var   
+        from flow_message_subscriptions
+       where msub_prcs_id = l_prcs_id;
+    ut.expect(l_actual).to_equal(l_expected).unordered;
+
+    case p_BE2_fires
+    when true then
+      -- want timer to fire first so wait before sending message
+      dbms_session.sleep(12);
+
+      -- check all subflows correct
+
+      open l_expected for
+         select
+         l_prcs_id as sbfl_prcs_id,
+         l_dgrm_id as sbfl_dgrm_id,
+         'Activity_AfterBE2' as sbfl_current,
+         flow_constants_pkg.gc_sbfl_status_running sbfl_status
+      from dual;
+
+      open l_actual for
+         select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_id
+         and sbfl_status not in ('split', 'in subprocess') ;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      -- check no message subscriptions outstanding
+
+      open l_actual for
+        select msub_prcs_id      as prcs_id
+             , msub_message_name as message_name
+             , msub_key_name     as message_key
+             , msub_key_value    as message_value
+             , msub_payload_var  as payload_var   
+          from flow_message_subscriptions
+         where msub_prcs_id = l_prcs_id;
+      ut.expect(l_actual).to_be_empty;    
+
+      -- step forward on BE subflow to end
+
+      test_helper.step_forward(pi_prcs_id => l_prcs_id, pi_current => 'Activity_AfterBE2');   
+
+    when false then
+      -- send message before BE times out
+      flow_api_pkg.receive_message ( p_message_name   => 'MyMessage'
+                                   , p_key_name       => 'MyKey'
+                                   , p_key_value      => 'Receive2'
+                                   );      
+
+      -- check subflows
+      open l_expected for
+         select
+         l_prcs_id as sbfl_prcs_id,
+         l_dgrm_id as sbfl_dgrm_id,
+         'Activity_AfterTest' as sbfl_current,
+         flow_constants_pkg.gc_sbfl_status_running sbfl_status
+      from dual;
+
+      open l_actual for
+         select sbfl_prcs_id, sbfl_dgrm_id, sbfl_current, sbfl_status 
+         from flow_subflows 
+         where sbfl_prcs_id = l_prcs_id
+         and sbfl_status not in ('split', 'in subprocess') ;
+      ut.expect( l_actual ).to_equal( l_expected ).unordered;
+
+      -- check no message subscriptions outstanding
+
+      open l_actual for
+        select msub_prcs_id      as prcs_id
+             , msub_message_name as message_name
+             , msub_key_name     as message_key
+             , msub_key_value    as message_value
+             , msub_payload_var  as payload_var   
+          from flow_message_subscriptions
+         where msub_prcs_id = l_prcs_id;
+      ut.expect(l_actual).to_be_empty;    
+
+      -- step forward on BE subflow to end
+
+      test_helper.step_forward(pi_prcs_id => l_prcs_id, pi_current => 'Activity_AfterTest');  
+
+    end case;
+
+    -- check process completed successfully
+
+    open l_expected for
+        select
+        l_dgrm_id                                     as prcs_dgrm_id,
+        l_prcs_name                                   as prcs_name,
+        flow_constants_pkg.gc_prcs_status_completed   as prcs_status
+        from dual;
+    open l_actual for
+        select prcs_dgrm_id, prcs_name, prcs_status 
+          from flow_processes p
+         where p.prcs_id = l_prcs_id;
+    ut.expect( l_actual ).to_equal( l_expected );    
+
+    -- tear down processes
+
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_id,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+  
+  end receivetask_timer_be_runner;
+
+  -- test(J1 - Timer BE on ReceiveTask)
+  procedure receivetask_timer_be_no_timers
+  is 
+  begin
+    receivetask_timer_be_runner ( p_be1_fires => false, p_be2_fires => false);
+  end receivetask_timer_be_no_timers;
+
+  -- test(J2 - Timer BE on ReceiveTask)
+  procedure receivetask_timer_be_int_timers
+  is 
+  begin
+    receivetask_timer_be_runner ( p_be1_fires => false, p_be2_fires => true);
+  end receivetask_timer_be_int_timers;
+
+  -- test(J3 - Timer BE on ReceiveTask)
+  procedure receivetask_timer_be_nonint_timers
+  is 
+  begin
+    receivetask_timer_be_runner ( p_be1_fires => true, p_be2_fires => false);
+  end receivetask_timer_be_nonint_timers;
+
+  -- test(J4 - Timer BE on ReceiveTask)
+  procedure receivetask_timer_be_both_timers
+  is 
+  begin
+    receivetask_timer_be_runner ( p_be1_fires => true, p_be2_fires => true);
+  end receivetask_timer_be_both_timers;
+
+
+  --afterall
+  procedure tear_down_tests  
+  is
+  begin
+    -- flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_a1,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    -- flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_a2,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    -- flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_b1,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    -- flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_b2,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    -- flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_c2,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    -- flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_d1,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    -- flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_d2,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    -- flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_e1,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    -- flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_e2,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    -- flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_f1,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    -- flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_f2,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    -- flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_g1,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+    -- flow_api_pkg.flow_delete(p_process_id  =>  g_prcs_id_g2,  p_comment  => 'Ran by utPLSQL as Test Suite 021');
+
+
+    ut.expect( v('APP_SESSION')).to_be_null;
+  end tear_down_tests;
+
+end test_021_messageFlow_basics;
+/

--- a/test/plsql/test_021_messageFlow_basics.pks
+++ b/test/plsql/test_021_messageFlow_basics.pks
@@ -1,0 +1,182 @@
+create or replace package test_021_messageFlow_basics as
+/* 
+-- Flows for APEX - test_021_messageFlow_basics.pks
+-- 
+-- (c) Copyright Oracle Corporation and / or its affiliates, 2023.
+--
+-- Created 17-Apr-2023   Richard Allen - Oracle
+--
+*/
+
+  -- uses models A21a
+
+  --%suite(21 MessageFlow Basics)
+  --%rollback(manual)
+
+  --%beforeall
+  procedure set_up_tests;
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests A: Basic Send to Waiting Catch - With Payload - All combinations of {send, Throw} to {receive, catch}
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  --%test(A1 - Send to Receive with Payload)
+  procedure basic_receive_send_payload;
+
+  --%test(A2 - ITE to Receive with Payload)
+  procedure basic_receive_ITE_payload;
+
+  --%test(A3 - Send to ICE with Payload)
+  procedure basic_ICE_send_payload;
+
+  --%test(A4 - ITE to ICE with Payload)
+  procedure basic_ICE_ITE_payload;  
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests B: Basic Send to Waiting Catch - Without Payloads - All combinations of {send, Throw} to {receive, catch}
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  --%test(B1 - Send to Receive with No Payload)
+  procedure basic_receive_send_no_payload;
+
+  --%test(B2 - ITE to Receive with No Payload)
+  procedure basic_receive_ITE_no_payload;
+
+  --%test(B3 - Send to ICE with No Payload)
+  procedure basic_ICE_send_no_payload;
+
+  --%test(B4 - ITE to ICE with No Payload)
+  procedure basic_ICE_ITE_no_payload;  
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests C: Throw to No Catch - All combinations of {send, Throw} to {receive, catch}
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  --%test(C1 - Send without Receive with  Payload)
+  procedure basic_send_without_receive_payload;
+
+  --%test(C2 - Throw without Receive with  Payload)
+  procedure basic_ITE_without_receive_payload;
+
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests D: Restorability of Send task after non-correlation error fixed
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  --%test(D1 - Error Restart after Send without Receive with Payload)
+  procedure basic_send_without_receive_payload_restart;
+
+  --%test(D2 - Error restart after Throw without Receive with Payload)
+  procedure basic_ITE_without_receive_payload_restart;
+
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests E: Bad Endpoints on Senders
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+  
+  --%test(E1 - Send with bad endpoint)
+  procedure bad_endpoint_send;
+
+ --%test(E2 - Send with bad endpoint)
+  procedure bad_endpoint_ITE;
+
+ 
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests F: Mismatched Payloads (send unexpected payload / missing expected payload)
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+   
+  --%test(F1 - Send to Receive with Unexpected Payload)
+  procedure basic_receive_send_unexpected_payload;
+
+  --%test(F2 - ITE to ICE with Unexpected Payload)
+  procedure basic_ICE_ITE_unexpected_payload;
+
+  --%test(F3 - Send to Receive with Missing Payload)
+  procedure basic_receive_send_missing_payload;
+
+  --%test(F4 - ITE to ICE with Missing Payload)
+  procedure basic_ICE_ITE_missing_payload;
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests G: Basic Send to Waiting Catch - With Payload - All combinations of {send, Throw} to {receive, catch}
+ --   (reruns set A with a diagram including Lanes and an empty pool)
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  --%test(G1 - Collaboration with Send to Receive with Payload)
+  procedure colab_receive_send_payload;
+
+  --%test(G2 - Collaboration with ITE to Receive with Payload)
+  procedure colab_receive_ITE_payload;
+
+  --%test(G3 - Collaboration with Send to ICE with Payload)
+  procedure colab_ICE_send_payload;
+
+  --%test(G4 - Collaboration with ITE to ICE with Payload)
+  procedure colab_ICE_ITE_payload;  
+
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests H: subscription Cancellation (check subscription gets cancelled when areceive Task gets cancelled)
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  --%test(H - Subscription Cancellation)
+  procedure subscription_cancellation;
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests I: MessageFlow ReceiveTask and ICE Following an Event Based Gateway
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  --%test(I1 - Messageflow after EBG - ReceiveTask wins)
+  procedure afterEBG_receiveTask;
+
+  --%test(I2 - Messageflow after EBG - MessageICE1 wins)
+  procedure afterEBG_messageICE1;
+
+    --%test(I3 - Messageflow after EBG - MessageICE2 wins)
+  procedure afterEBG_messageICE2;
+
+    --%test(I4 - Messageflow after EBG - Timer wins)
+  procedure afterEBGtimer;
+
+  --%afterall
+  procedure tear_down_tests;
+
+
+ ---------------------------------------------------------------------------------------------------------------
+ --
+ --  Tests J: Timer Boundary Events on ReceiveTask
+ -- 
+ ---------------------------------------------------------------------------------------------------------------
+
+  --%test(J1 - Timer BE on ReceiveTask - both not firing)
+  procedure receivetask_timer_be_no_timers;
+
+  --%test(J2 - Timer BE on ReceiveTask - Int Fires)
+  procedure receivetask_timer_be_int_timers;
+
+  --%test(J3 - Timer BE on ReceiveTask - NonInt Fires)
+  procedure receivetask_timer_be_nonint_timers;
+
+  --%test(J4 - Timer BE on ReceiveTask - Both Fire)
+  procedure receivetask_timer_be_both_timers;
+
+end test_021_messageFlow_basics;
+/


### PR DESCRIPTION
- adds test suites for message flow.
- fixes exception handling when sent message is not expected
- enables ReceiveTask to follow an Event Based Gateway
- enables Interrupting and Non-Interupting Timer Boundary Events on ReceiveTask
- fixes problem with message flow after EventBasedGateway
- adds test suite 21 for message flow
- INCLUDES TEMPORARY CHANGE to flow_tasks and parsing of models in Suite 21 to work around current parser task type bug and payloadVariable bugs WHICH NEED FIXING BEFORE PRODUCTION