### PR TITLE
Update flow_subflows_vw.sql

### DIFF
--- a/src/views/flow_subflows_vw.sql
+++ b/src/views/flow_subflows_vw.sql
@@ -63,6 +63,6 @@ left join flow_connections conn
 left join flow_timers timr
        on timr.timr_prcs_id = sbfl.sbfl_prcs_id
       and timr.timr_sbfl_id = sbfl.sbfl_id
-      and timr.timr_status != 'E'
+      and timr.timr_status in ('C', 'A', 'B')
 with read only
 ;


### PR DESCRIPTION
Fix for #652 the subflows view should only return active, created and error timers