### PR TITLE
fix [bug]: reschedule an interrupting timer #710

### DIFF
--- a/src/plsql/flow_engine.pkb
+++ b/src/plsql/flow_engine.pkb
@@ -1118,11 +1118,12 @@ begin
       ;
       flow_timers_pkg.reschedule_timer
       ( 
-        p_process_id       => p_sbfl_rec.sbfl_prcs_id
-      , p_subflow_id      => p_sbfl_rec.sbfl_id
-      , p_step_key     => p_sbfl_rec.sbfl_step_key
-      , p_is_immediate  => true
-      , p_comment       => 'Restart Immediate Broken Timer'
+        p_process_id          => p_sbfl_rec.sbfl_prcs_id
+      , p_subflow_id          => p_sbfl_rec.sbfl_id
+      , p_step_key            => p_sbfl_rec.sbfl_step_key
+      , p_restart_immediate   => true
+      , p_is_immediate        => true
+      , p_comment             => 'Restart Immediate Broken Timer'
       );
 
 end restart_failed_timer_step;

--- a/src/plsql/flow_timers_pkg.pkb
+++ b/src/plsql/flow_timers_pkg.pkb
@@ -830,12 +830,13 @@ create or replace package body flow_timers_pkg as
 
 procedure reschedule_timer
 (
-    p_process_id    in flow_processes.prcs_id%type
-  , p_subflow_id    in flow_subflows.sbfl_id%type
-  , p_step_key      in flow_subflows.sbfl_step_key%type default null
-  , p_is_immediate  in boolean default false
-  , p_new_timestamp in flow_timers.timr_start_on%type default null
-  , p_comment       in flow_instance_event_log.lgpr_comment%type default null
+    p_process_id        in flow_processes.prcs_id%type
+  , p_subflow_id        in flow_subflows.sbfl_id%type
+  , p_step_key          in flow_subflows.sbfl_step_key%type default null
+  , p_is_immediate      in boolean default false
+  , p_restart_immediate in boolean default false
+  , p_new_timestamp     in flow_timers.timr_start_on%type default null
+  , p_comment           in flow_instance_event_log.lgpr_comment%type default null
 )
 is
   l_timer_rec       flow_timers%rowtype;
@@ -851,14 +852,39 @@ begin
   , 'New Timestamp', p_new_timestamp
   );
   -- lock the timer
-  select *
-    into l_timer_rec
-    from flow_timers timr 
-   where timr.timr_prcs_id = p_process_id
-     and timr.timr_sbfl_id = p_subflow_id
-     and timr.timr_status = flow_timers_pkg.c_created
-     for update wait 5
-  ;
+  -- first try to lock a current active (i.e., 'created') timer on the subflow
+  begin
+    select *
+      into l_timer_rec
+      from flow_timers timr 
+     where timr.timr_prcs_id = p_process_id
+       and timr.timr_sbfl_id = p_subflow_id
+       and timr.timr_status = flow_timers_pkg.c_created
+       for update wait 5
+    ;
+  exception
+    when no_data_found then
+      if p_restart_immediate then
+        -- handle timer event restarts where timer has already fired but step needs to be re-started
+        -- requires the old 'nded' timer to be restarted with an imediate schedule. (See test case 3h2 Issue #710)
+        select *
+          into l_timer_rec
+          from flow_timers timr 
+         where timr.timr_last_run = ( select max (timr_last_run )
+                                      from   flow_timers 
+                                      where  timr_prcs_id = p_process_id
+                                      and    timr_sbfl_id = p_subflow_id
+                                      and    timr.timr_status = flow_timers_pkg.c_ended
+                                    )
+           and timr_prcs_id = p_process_id
+           and timr_sbfl_id = p_subflow_id
+           and timr.timr_status = flow_timers_pkg.c_ended
+           for update wait 5
+        ;
+      else
+        raise;
+      end if;
+  end;
   if flow_engine_util.step_key_valid( pi_prcs_id  => p_process_id
                                     , pi_sbfl_id  => p_subflow_id
                                     , pi_step_key_supplied  => p_step_key

--- a/src/plsql/flow_timers_pkg.pks
+++ b/src/plsql/flow_timers_pkg.pks
@@ -69,12 +69,13 @@ as
 
 procedure reschedule_timer
 (
-    p_process_id    in flow_processes.prcs_id%type
-  , p_subflow_id    in flow_subflows.sbfl_id%type
-  , p_step_key      in flow_subflows.sbfl_step_key%type default null
-  , p_is_immediate  in boolean default false
-  , p_new_timestamp in flow_timers.timr_start_on%type default null
-  , p_comment       in flow_instance_event_log.lgpr_comment%type default null
+    p_process_id        in flow_processes.prcs_id%type
+  , p_subflow_id        in flow_subflows.sbfl_id%type
+  , p_step_key          in flow_subflows.sbfl_step_key%type default null
+  , p_is_immediate      in boolean default false
+  , p_restart_immediate in boolean default false
+  , p_new_timestamp     in flow_timers.timr_start_on%type default null
+  , p_comment           in flow_instance_event_log.lgpr_comment%type default null
 );
 
 


### PR DESCRIPTION
Fixes Issue #710 

Timers can now be rescheduled if the subflow contains other timer events that have already completed, and can be restarted to fire immediately if a timer start event fails due to bad variable expression execution (so timer ended successfully but the step failed, requiring restart).

Passes regression.