### PR TITLE
make diagrams releasable from admin api by name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,17 +1,24 @@
-# Flows for APEX - Changelog #
+# Flows for APEX - Changelog
 
-## v23.1 ##
+## v24.1
+
+- Adds JSON-typed process variables.
+- Adds BPMN-Color support into the Modeler and Viewer, allowing shading of BPMN objects on a diagram.  Colors can optionally then also be shown in the process viewer.
+- Enhances flow_admin_api so that a diagram can be 'released' from the API.  This is useful for remote deployment of diagrams into production environments.
+- Required APEX version increased to APEX v22.1
+
+## v23.1
 
 - Adds Due Dates and Priorities to bpmn:processes and to bpmn:userTasks, allowing declarative tracking of scheduling, priority and due dates.
 - Adds Task Assignment to bpmn:userTasks, allowing easier declarative assignment of tasks to potential users and groups.
-- Adds REST-enabling of the Flows for APEX API 
+- Adds REST-enabling of the Flows for APEX API
 - Major upgrade to the BPMN Modeler, with new, modern-looking properties panel.
 - Enhanced support for modeling and viewing of collapsed subProcesses that can be easily expanded / collapsed.
 - Adds support for BPMN Child Lane sets, allowing nesting of lane sets inside parent lanes.
 - Adds explicit definition of relationship (or not) between Lanes and APEX roles/groups.
 - Adds Timestamp with Time Zone datatype option for Process Variables.
 - Adds binding of Process Variables into PL/SQL scripts, variable expressions, and element settings.
-- Adds support for binding non-varchar2 typed (i.e., number, date, timestamp with time zone) process variables. 
+- Adds support for binding non-varchar2 typed (i.e., number, date, timestamp with time zone) process variables.
 - Allows process variable substitutions to be used in all of the parameters of an APEX Page task.
 - Adds 'is Startable' information to Processes, along with users and groups that can start a process.
 - Allows BPMN diagrams to contain Groups and attached Annotations.
@@ -26,7 +33,7 @@
 - Adds support for additional languages Italian, Simplified Chinese, Traditional Chinese, Korean.
 - Required APEX version increased to APEX v20.2
 
-## v22.2 ##
+## v22.2
 
 - Adds BPMN Call Activities, allowing a process diagram to call another process diagram, passing and returning in/out variables.
 - Adds scoping to process variables at diagram level to support call activities.
@@ -44,28 +51,29 @@
 - Simplifies translation framework, allowing contributors to more easily supply translations to be incorporated into the product.
 - Adds new translations to support Brazilian Portuguese (pt-BR), German (de), Spanish (es), and Japanese (ja).
 - Enhanced engine testing regime now introduced through utPLSQL regression test suites.
-- Enhanced sample app "Expense Claims" to reflect features added to Flows for APEX v22.2. 
+- Enhanced sample app "Expense Claims" to reflect features added to Flows for APEX v22.2.
 
-## v22.1 ##
+## v22.1
 
 - Adds repeating timers for non-interrupting boundary events - facilitating repeated reminders.
-
 - Adds BPMN Business Rules Task type, which can accept user-defined PL/SQL script for linking to credit scoring, ML models or other automated decision tasks.
 - Adds the ability to declaratively define sending an email from a Service Task
 - Improves Timer Usability, by allowing timers to be specified using Oracle data and interval syntax in addition to ISO 8601 format.
 - Improves multi-user integrity by adding a unique Step Key as part of the context for each process object.
 - Improvements to the Flow Engine Application, with enhancements to the Flow Modeler:
+  
   - Addition of the Monaco text editor for PL/SQL input to variable expressions and script code entry.
   - Use of APEX metadata in UI for specifying links to APEX pages and page items.
 - Enhances the step operations plugin so that it can issue the flow_start_step command.
 - Separates private and public calls and views used by the Flow Engine Application to ease reuse by customer apps.
 - Added flow_globals.step_key and flow_globals.business_ref to get these values.
-- Enhanced the sample app "Expense Claims" to reflect all features added to Flows for APEX 22.1. 
+- Enhanced the sample app "Expense Claims" to reflect all features added to Flows for APEX 22.1.
 
-## v21.1 ##
+## v21.1
 
 - Introduces model-based declarative process variable expressions to set process variables before and after each step.
 - Introduces 3 process plugins to ease application integration:
+  
   - Manage Flow Instance, for controlling instance creation, starting, termination, reset and deletion.
   - Manage Flow Instance Step, for controlling step statrt, reservation, release and completion.
   - Manage Flow Instance Variables, for transferring process variable content to and from APEX page items.
@@ -75,7 +83,7 @@
 - Steps halted with error status can be re-started after an administrator fixes the problem.
 - Introduces Monitoring and Auditing event logs of Instances, instance steps, and process variables
 - Major upgrade of the Flow Engine Application, with enhancements to the modeler, viewer, and the app UI.
-
+  
   - App: enhanced UI, including support for dark mode
   - App: Flow Monitor additionally supports side-by-side and multi-monitor support for administering larger systems.
   - Modeler: Properties panel can now be expanded by dragging
@@ -97,7 +105,7 @@
 - Removes deprecated v4 API calls flow_next_step, flow_next_branch.
 - Removes next_step_type from subflow view (non longer required since V4)
 
-## v5.1.2 ##
+## v5.1.2
 
 - Added business reference to views
   - flow_task_inbox_vw
@@ -106,7 +114,7 @@
 - Introduced the demo app "Holiday Approval"
 - The demo app "Order Shipment" is now deprecated
 
-## v5.1.1 ##
+## v5.1.1
 
 - Fixed several bugs occuring when all of the objects after an event object or a gateway are scriptTasks or serviceTasks, causing process not to be marked as Completed when finished.
 - Fixed a bug causing the first task after an Interrupting Escalation Boundary Event to be skipped
@@ -114,7 +122,7 @@
 - Fixed a problem with diagram export file names being too long
 - Fixed serviceTask missing engine option for type "Run PL/SQL code"
 
-## v5.1.0 ##
+## v5.1.0
 
 - Introduces process diagram versioning and lifecycle management.
 - Supports diagram import and export to XML or SQL files from the Flows for APEX application.
@@ -127,7 +135,7 @@
 - Added upgrade support to installation process.
 - Hey, we even have our own logo now!
 
-## v5.0.1 ##
+## v5.0.1
 
 - Enables process variables to be used when specifying timer definitions
 - Fixed bug that rises when reusing an ID across flows
@@ -137,7 +145,7 @@
 - When processing timers errors that occur mark respective timer as broken but don't break job anymore
 - Added "Add Gateway Route" to Flow Control for convenience when adding a process variable for a gateway
 
-## v5.0.0 ##
+## v5.0.0
 
 - Support for userTask objects that can now run an APEX page, defined inside modeler
 - Support for scriptTask objects that can run a PL/SQL script, defined inside modeler
@@ -161,7 +169,7 @@
 - Enhanced documentation.
 - Cleaner flow_api_pkg by separation of engine components into flow_engine
 
-## v4.0.0 ##
+## v4.0.0
 
 - New Subflow architecture to support Parallel Gateways, Sub Processes
 - Support for subprocesses (n levels deep)
@@ -178,24 +186,25 @@
   - Timed Start Events
   - Timer Intermediate Catch Events
 
-## v3.0.0 ##
+## v3.0.0
 
 - XML parsing now done using PL/SQL only
 - Upgraded all bpmn.io libraries to 7.2.0
 - Support for subprocesses (one level deep)
 - Fixed minor bugs and adopted coding standards
 
-## v2.0.0 ##
+## v2.0.0
 
 - Reworked API package
 - Added demo app
 - Checked for coding standards
 
-## v1.0.1 ##
+## v1.0.1
 
 - Fixed a few bugs
 - Annotations in Flows are now supported
 
-## v1.0 ##
+## v1.0
 
 - Initial Release
+

--- a/src/plsql/flow_admin_api.pkb
+++ b/src/plsql/flow_admin_api.pkb
@@ -101,5 +101,19 @@ The `flow_admin_api` package gives you access to the Flows for APEX engine admin
                                              );       
   end get_config_value;
 
+  -- Diagram Release
+
+  procedure release_diagram
+  ( pi_dgrm_name    in flow_diagrams.dgrm_name%type,
+    pi_dgrm_version in flow_diagrams.dgrm_version%type default '0' 
+  )
+  is
+  begin 
+    flow_diagram.release_diagram
+    ( pi_dgrm_name    => pi_dgrm_name
+    , pi_dgrm_version => pi_dgrm_version
+    );
+  end release_diagram;
+
 end flow_admin_api;
 /

--- a/src/plsql/flow_admin_api.pks
+++ b/src/plsql/flow_admin_api.pks
@@ -11,10 +11,11 @@ create or replace package flow_admin_api
 FLOWS FOR APEX ADMIN API
 =========================
 
-The `flow_admin_api` package gives you access to the Flows for APEX engine admin procedures, and allows you to perform:
+The `flow_admin_api` package gives you access to the Flows for APEX engine admin procedures, and allows you to perform the following from the PL/SQL API:
 -  Maintenance, Archiving and Purging of the Flows for APEX log files
 -  Maintenance, Archiving, and Purging of the Flows for APEX performance statistics all_summaries
-- Maintenance of Flows for APEX instance configuration parameters
+-  Maintenance of Flows for APEX instance configuration parameters
+-  Release of Diagrams (useful when introducing a new model into a production system).
 
 */
 -- Log File Functions
@@ -50,6 +51,13 @@ The `flow_admin_api` package gives you access to the Flows for APEX engine admin
   ( p_config_key        in flow_configuration.cfig_key%type
   , p_default_value     in flow_configuration.cfig_value%type
   ) return flow_configuration.cfig_value%type;
+
+-- release a diagram
+
+  procedure release_diagram
+  ( pi_dgrm_name    in flow_diagrams.dgrm_name%type,
+    pi_dgrm_version in flow_diagrams.dgrm_version%type default '0'
+  );
 
 end flow_admin_api;
 /

--- a/src/plsql/flow_diagram.pkb
+++ b/src/plsql/flow_diagram.pkb
@@ -606,6 +606,19 @@ as
 
   end release_diagram;
 
+  procedure release_diagram(
+    pi_dgrm_name    in flow_diagrams.dgrm_name%type,
+    pi_dgrm_version in flow_diagrams.dgrm_version%type default '0')
+  is
+    l_dgrm_id  flow_diagrams.dgrm_id%type;
+  begin
+    l_dgrm_id :=  get_current_diagram
+                  ( pi_dgrm_name              => pi_dgrm_name
+                  , pi_dgrm_calling_method    => flow_constants_pkg.gc_dgrm_version_named_version
+                  , pi_dgrm_version           => pi_dgrm_version
+                  );
+    release_diagram (pi_dgrm_id => l_dgrm_id);
+  end release_diagram;
 
   procedure deprecate_diagram(
     pi_dgrm_id in flow_diagrams.dgrm_id%type)

--- a/src/plsql/flow_diagram.pks
+++ b/src/plsql/flow_diagram.pks
@@ -99,6 +99,12 @@ as
     pi_dgrm_id in flow_diagrams.dgrm_id%type);
 
 
+  -- Exposed as Public API through flow_admin_api
+  procedure release_diagram(
+    pi_dgrm_name    in flow_diagrams.dgrm_name%type,
+    pi_dgrm_version in flow_diagrams.dgrm_version%type default '0');
+
+
   procedure deprecate_diagram(
     pi_dgrm_id in flow_diagrams.dgrm_id%type);
 


### PR DESCRIPTION
Creates a new procedure flow_diagrams.release_diagram by name, and exposes this in flow_admin_api.

This is useful to us internally to make regression test installation automatable now that messageflow tests that include message start events must be released prior to use.

This has also been a requested feature for customers creating production deployments where you need to script the deployment of a model into a remote production environment and then release it.