### PR TITLE
fix tests that leave running processes

### DIFF
--- a/test/plsql/test_010_variable_expression.pks
+++ b/test/plsql/test_010_variable_expression.pks
@@ -49,7 +49,7 @@ create or replace package test_010_variable_expressions is
     --%test('Variable expressions process completed as expected')
     procedure var_exp_process_completed;
 
-    --afterall
+    --%afterall
     procedure tear_down_process;
 
 end test_010_variable_expressions;

--- a/test/plsql/test_021_messageFlow_basics.pkb
+++ b/test/plsql/test_021_messageFlow_basics.pkb
@@ -782,6 +782,7 @@ create or replace package body test_021_messageFlow_basics as
     -- tear down processes
 
     flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
   end basic_send_without_receive_payload_restart;
 
 
@@ -885,6 +886,7 @@ create or replace package body test_021_messageFlow_basics as
     -- tear down processes
 
     flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_tx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
+    flow_api_pkg.flow_delete(p_process_id  =>  l_prcs_rx,  p_comment  => 'Ran by utPLSQL as Test Suite 021');    
   end basic_ITE_without_receive_payload_restart;
 
 

--- a/test/plsql/test_022_usertask_misc.pkb
+++ b/test/plsql/test_022_usertask_misc.pkb
@@ -242,7 +242,7 @@ create or replace package body test_022_usertask_misc as
   procedure pagetask_substitutions_2
   is
   begin
-    g_prcs_id_a1 := pagetask_substitution_runner ( p_path        => 'B'
+    g_prcs_id_a2 := pagetask_substitution_runner ( p_path        => 'B'
                                                 , p_app_id      => '200'
                                                 , p_page_id     => '2'
                                                 , p_request     => 'UPDATE'


### PR DESCRIPTION
Regression tests currently always create a few more processes than they delete.   This fixes the 3 tests that don't clean up properly...