### PR TITLE
Merge pull request #737 from flowsforapex/fix/make-loop-counter-avail-for-substitution

### DIFF
--- a/src/plsql/flow_settings.pkb
+++ b/src/plsql/flow_settings.pkb
@@ -4,11 +4,11 @@ as
 -- Flows for APEX - flow_settings.pkb
 -- 
 -- (c) Copyright Oracle Corporation and / or its affiliates, 2022-2023.
--- (c) Copyright Flowquest Consulting Limited. 2024
+-- (c) Copyright Flowquest Limited. 2024
 --
 -- Created    23-Nov-2022  Richard Allen (Oracle)
 -- Modified   13-Apr-2023  Moritz Klein (MT GmbH)
--- Modified   11-Feb-2024  Richard Allen (Flowquest Consulting)
+-- Modified   11-Feb-2024  Richard Allen (Flowquest Limited)
 --
 */
 
@@ -43,6 +43,13 @@ as
     l_return.expr_inside_var        := pi_expr_json.get_string( key => 'insideVariable' );
     l_return.expr_description       := pi_expr_json.get_string( key => 'description');
 
+    apex_debug.message (p_message => 'get_expression_details - results.  expr_value %0 expr_type %1 expr_fmt %2 expr_inside_var %3 expr_desc %4'
+    , p0 => l_return.expr_value
+    , p1 => l_return.expr_type
+    , p2 => l_return.expr_fmt
+    , p3 => l_return.expr_inside_var
+    , p4 => l_return.expr_description
+    );
     return l_return;
   end get_expression_details;
 
@@ -528,7 +535,12 @@ as
     l_details := get_expression_details ( pi_expr_json  => pi_expr);
 
     l_settings.type              := l_details.expr_type;
-    l_settings.collection_var    := l_details.expr_value;
+    case  l_settings.type 
+    when flow_constants_pkg.gc_expr_type_sql_json_array then
+          l_settings.collection_expr   := l_details.expr_value;
+    else 
+          l_settings.collection_var    := l_details.expr_value;
+    end case;
     l_settings.inside_var        := l_details.expr_inside_var;
     l_settings.description       := l_details.expr_description;
     return l_settings;

--- a/src/plsql/flow_types_pkg.pks
+++ b/src/plsql/flow_types_pkg.pks
@@ -3,10 +3,10 @@ create or replace package flow_types_pkg
 -- Flows for APEX - flow_types_pkg.pks
 -- 
 -- (c) Copyright MT AG, 2020-2022.
--- (c) Copyright Flowquest Consulting Limited. 2024.
+-- (c) Copyright Flowquest Limited. 2024.
 --
 -- Created  11-Sep-2020  Moritz Klein (MT AG)
--- Modified 09-Jan-2024  Richard Allen, Flowquest Consulting
+-- Modified 09-Jan-2024  Richard Allen, Flowquest Limited
 --
 */
   authid definer
@@ -51,9 +51,21 @@ as
   , scope             flow_subflows.sbfl_scope%type
   );
 
+  -- Type              -- t_iteration_vars
+  -- Purpose           -- used to hold the input, output, or description expression sub-components of an iteration definition
+  -- type              -- gc_expr_type_sql_json_array
+                       -- gc_expr_type_list
+                       -- gc_expr_type_array 
+  -- collection_var    -- if the expression is a process varuable, this contains the variable name
+  -- collection_expr   -- if the expression is a SQL Query, PLSql function, etc., this contains the expression text
+                       -- note that the expresion can be longer than a variable name, so you need to use this for the actual
+                       -- expression
+  -- inside_var        -- variable name to be used inside the iteration (so inport to these / export from these)
+  -- description       -- the description string, typically contains substitution parameters
   type t_iteration_vars is record
   ( type            flow_types_pkg.t_vc20
   , collection_var  flow_process_variables.prov_var_name%type
+  , collection_expr t_bpmn_attribute_vc2
   , inside_var      flow_process_variables.prov_var_name%type
   , description     varchar2(4000)
   );


### PR DESCRIPTION
Fix to messageFlow to allow multiple interrupting message boundary events to be attached to a single task, sub bprocess or call activity.

Uses the callback parameter mechanism already in place to allow multiple message start events in a diagram.

related fix and PR  in flows-apex-enterprise in flow_iteration.pkb