### PR TITLE
fix null handling for set proc var from json

### DIFF
--- a/src/plsql/flow_proc_vars_int.pkb
+++ b/src/plsql/flow_proc_vars_int.pkb
@@ -1007,6 +1007,9 @@ end lock_var;
         when pi_json.get(l_keys(i)).is_timestamp then
           l_var.var_type  := flow_constants_pkg.gc_prov_var_type_tstz;
           l_var.var_tstz  := pi_json.get_timestamp(l_keys(i));  
+        when  pi_json.get(l_keys(i)).is_null then
+          apex_debug.info (p_message => 'Element name %0 is null - not creating proc var', p0 => l_var.var_name);
+          continue;
         end case;
       when 'OBJECT' then
           l_var.var_type  := flow_constants_pkg.gc_prov_var_type_json;
@@ -1021,7 +1024,7 @@ end lock_var;
       , p0        => l_var.var_name
       , p1        => l_var.var_type
       );
-
+      
       set_var 
       ( pi_prcs_id      => pi_prcs_id
       , pi_var_value    => l_var

--- a/src/plsql/flow_proc_vars_int.pks
+++ b/src/plsql/flow_proc_vars_int.pks
@@ -220,6 +220,7 @@ procedure set_vars_from_json_object
 , pi_json         in sys.json_object_t
 , pi_objt_bpmn_id in flow_objects.objt_bpmn_id%type default null
 );
+-- note  that if a json element is null, the process variable does not get created.
 
 procedure delete_all_for_process
 ( pi_prcs_id in flow_processes.prcs_id%type


### PR DESCRIPTION
fixes a bug when setting proc vars from json if the element is null.  Previously caused error - now just ignores the element and does not create proc var for it.