### PR TITLE
Add License info to config parameters

### DIFF
--- a/src/data/install_default_config_data.sql
+++ b/src/data/install_default_config_data.sql
@@ -26,7 +26,10 @@ begin
   flow_admin_api.set_config_value ( p_update_if_set => false, p_config_key => 'rest_base'                                     ,p_value => null );
   flow_admin_api.set_config_value ( p_update_if_set => false, p_config_key => 'logging_archive_location'                      ,p_value => null );
   flow_admin_api.set_config_value ( p_update_if_set => false, p_config_key => 'logging_bpmn_location'                         ,p_value => null );
-  flow_admin_api.set_config_value ( p_update_if_set => false, p_config_key => 'licence_edition'                               ,p_value => 'community' );
+  flow_admin_api.set_config_value ( p_update_if_set => false, p_config_key => 'license_edition'                               ,p_value => 'community' );
+  flow_admin_api.set_config_value ( p_update_if_set => false, p_config_key => 'license_key'                                   ,p_value => '' );
+  flow_admin_api.set_config_value ( p_update_if_set => false, p_config_key => 'licensed_to'                                   ,p_value => '' );
+  flow_admin_api.set_config_value ( p_update_if_set => false, p_config_key => 'license_expiry_date'                           ,p_value => '' );
 
   commit;
 end;

--- a/src/migrations/23.1_to_24.1/feature-add-edition.sql
+++ b/src/migrations/23.1_to_24.1/feature-add-edition.sql
@@ -4,8 +4,14 @@
   Created  RAllen   13 May 2024
 
 
-  (c) Copyright Flowquest Consulting Limited and/or its affiliates.  2024.
+  (c) Copyright Flowquest Limited and/or its affiliates.  2024.
 
 */
 
-  flow_admin_api.set_config_value ( p_update_if_set => false, p_config_key => 'licence_edition',p_value => 'community' );
+begin
+  flow_admin_api.set_config_value ( p_update_if_set => false, p_config_key => 'license_edition'                               ,p_value => 'community' );
+  flow_admin_api.set_config_value ( p_update_if_set => false, p_config_key => 'license_key'                                   ,p_value => '' );
+  flow_admin_api.set_config_value ( p_update_if_set => false, p_config_key => 'licensed_to'                                   ,p_value => '' );
+  flow_admin_api.set_config_value ( p_update_if_set => false, p_config_key => 'license_expiry_date'                           ,p_value => '' );
+end;
+/

--- a/src/plsql/flow_constants_pkg.pks
+++ b/src/plsql/flow_constants_pkg.pks
@@ -357,7 +357,10 @@ as
   gc_config_stats_retain_summary_daily  constant varchar2(50 char) := 'stats_retain_daily_summaries_days';
   gc_config_stats_retain_summary_month  constant varchar2(50 char) := 'stats_retain_monthly_summaries_months';
   gc_config_stats_retain_summary_qtr    constant varchar2(50 char) := 'stats_retain_quarterly_summaries_months';
-  gc_config_edition                     constant varchar2(50 char) := 'license_edition';
+  gc_config_license_edition             constant varchar2(50 char) := 'license_edition';
+  gc_config_license_key                 constant varchar2(50 char) := 'license_key';
+  gc_config_licensed_to                 constant varchar2(50 char) := 'licensed_to';
+  gc_config_license_expiry_date         constant varchar2(50 char) := 'license_expiry_date';
 
 
 -- Config Parameter Valid Values (when not true / false or numeric)


### PR DESCRIPTION
Add license tracking parameters to config so that they can be displayed in Engine App.  